### PR TITLE
Additional constituencies for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Constiuencies we want to ensure input and review from:
 * Adtech intermediaries
 * Advertising buyers
 * Privacy theorists and legal scholars
+* Behavioral economists
 * Those working on emerging Web tech such as WebXR and new device APIs
 * Web developers
 * People who use the web
 * People representing marginalised communities on the web
 * TAG and PING chairs and team contacts
+* User researchers
 * WhatWG steering board
 
 Input documents:


### PR DESCRIPTION
Suggesting two new sets of experts for the constituencies section.

Behavioral economists: The behavioral economics of advertising is more complicated that it looks. Most of the web advertising literature focuses on a relatively simple data-for-content exchange, similar to how the reader of a controlled circulation magazine would fill out a survey about all the stuff they're responsible for buying at their company in order to receive a free subscription. This is one model for one kind of advertising, but doesn't capture other kinds of exchanges, particularly the incentives of users to supply, conceal, or misrepresent their personal information, or the incentives to actually pay attention to different ad formats.

User researchers: The more we learn about user privacy preferences, the more we learn that there really are different kinds of people. Some fields may have over-representation of people with particular sets of privacy norms, so it would be helpful to draw on and interpret the literature on the prevalence of different privacy norms and preferences among real Web users. (People who use the web are already listed, but studies involving more people than we can talk to directly would be informative.)