### PR TITLE
Add Makefile rules for building a snapshot with respec on the command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,15 @@
+.PHONY: all clean update-toc
+
+all: build/index.html update-toc
+
+clean:
+	rm -rf build *~
+
+build:
+	mkdir -p build
+
+build/%.html: %.html Makefile build
+	respec --src $< --out $@
+
 update-toc:
 	doctoc README.md

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# How to snapshot the Privacy Principles document -*- makefile-gmake -*-
+
+# This Makefile expects respec and doctoc to be installed, both of which
+# may be installed with NPM. Additionally, respec requires you to have
+# Google Chrome installed. This Makefile checks for Chrome in the
+# default install locations on macOS and Linux. TODO: make this work on
+# Windows too.
+
 .PHONY: all clean update-toc
 
 all: build/index.html update-toc
@@ -8,8 +16,20 @@ clean:
 build:
 	mkdir -p build
 
+# There has got to be a cleaner way to do this.
+PUPPETEER_SKIP_DOWNLOAD = 1
+export PUPPETEER_SKIP_DOWNLOAD
+CHROME_ON_MAC="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+CHROME_ON_LINUX="/usr/bin/google-chrome"
 build/%.html: %.html Makefile build
-	respec --src $< --out $@
+	if [[ -f $(CHROME_ON_MAC) ]]; then \
+		export PUPPETEER_EXECUTABLE_PATH=$(CHROME_ON_MAC); \
+		respec --src $< --out $@; \
+	fi
+	if [[ -f $(CHROME_ON_LINUX) ]]; then \
+		export PUPPETEER_EXECUTABLE_PATH=$(CHROME_ON_LINUX); \
+		respec --src $< --out $@; \
+	fi
 
 update-toc:
 	doctoc README.md


### PR DESCRIPTION
I'm trying to make it so that simply typing 'make' in this directory does whatever it needs to do to produce a snapshot, just like the TAG's other documents. I've only tested this Makefile on macOS. Could someone test it on Linux? And if any of us live on Windows, could you update it to work there?