### PR TITLE
Remove noexport attributes left over from Bikeshed import.

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,7 +807,7 @@ Security and Privacy Self-Review Questionnaire</a>:
 communications or activities. See <a
 data-cite="RFC6973#section-5.1.1">RFC6973§5.1.1</a>.
 
-<dt><dfn noexport>Stored Data Compromise</dfn>
+<dt><dfn>Stored Data Compromise</dfn>
 
 <dd> End systems that do not take adequate measures to secure stored data from
     unauthorized or inappropriate access. See <a
@@ -852,7 +852,7 @@ data-cite="RFC6973#section-5.2.3">RFC6973§5.2.3</a>.
     the way others judge the individual. See <a
 data-cite="RFC6973#section-5.2.4">RFC6973§5.2.4</a>.
 
-<dt><dfn noexport>Exclusion</dfn>
+<dt><dfn>Exclusion</dfn>
 
 <dd>Exclusion is the failure to allow individuals to know about the data that
     others have about them and to participate in its handling and use. See


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/19.html" title="Last updated on Jul 7, 2021, 11:50 PM UTC (c084256)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/19/3e89277...jyasskin:c084256.html" title="Last updated on Jul 7, 2021, 11:50 PM UTC (c084256)">Diff</a>