### PR TITLE
Rewrite the abstract to align with the style guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,15 +227,14 @@
 
 <section id="abstract">
 
-Privacy has been an essentially contested concept [[?PRIVACY-CONTESTED]]. Its debated meaning
-render its support problematic in the context of a standards-setting process grounded in
-consensus [[?W3C-PROCESS]], in seeking out technical solutions grounded on shared
-requirements, and in addressing the needs of a worldwide constituency. This document
-provides definitions for privacy and related concepts that are suitable for a global
-audience, that can provide building blocks for privacy threat modelling, and can guide the
-development of the Web as a trustworthy platform. In the spirit of building a much-needed
-bridge between technology and policy, this document is written under the expectation that
-it can apply to both.
+There has been a lot of debate about privacy in the Web community [[?PRIVACY-CONTESTED]].
+This debate can make it difficult to reach consensus [[?W3C-PROCESS]] on the right
+technical means to support privacy, especially in a manner that applies to the entire
+world and across many different local laws. This document provides definitions for privacy
+and related concepts that are applicable worldwide. It also provides a privacy threat model
+and can guide the development of the Web as a trustworthy platform. Users of the Web would
+benefit from a stronger relationship between technology and policy, and this document is
+written to work with both.
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -227,14 +227,11 @@
 
 <section id="abstract">
 
-There has been a lot of debate about privacy in the Web community [[?PRIVACY-CONTESTED]].
-This debate can make it difficult to reach consensus [[?W3C-PROCESS]] on the right
-technical means to support privacy, especially in a manner that applies to the entire
-world and across many different local laws. This document provides definitions for privacy
-and related concepts that are applicable worldwide. It also provides a privacy threat model
-and can guide the development of the Web as a trustworthy platform. Users of the Web would
-benefit from a stronger relationship between technology and policy, and this document is
-written to work with both.
+Privacy is an essential part of the Web [[?ETHICAL-WEB]]. This document provides definitions
+for privacy and related concepts that are applicable worldwide. It also provides a privacy
+threat model and can guide the development of the Web as a trustworthy platform. Users of
+the Web would benefit from a stronger relationship between technology and policy, and this
+document is written to work with both.
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -228,8 +228,8 @@
 <section id="abstract">
 
 Privacy is an essential part of the Web [[?ETHICAL-WEB]]. This document provides definitions
-for privacy and related concepts that are applicable worldwide. It also provides a privacy
-threat model and can guide the development of the Web as a trustworthy platform. Users of
+for privacy and related concepts that are applicable worldwide. It also provides a set of privacy
+principles that should guide the development of the Web as a trustworthy platform. Users of
 the Web would benefit from a stronger relationship between technology and policy, and this
 document is written to work with both.
 


### PR DESCRIPTION
I tried to apply the style guide to the abstract, as per #15.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/29.html" title="Last updated on Aug 11, 2021, 4:52 PM UTC (d04ecd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/29/76c14bc...d04ecd3.html" title="Last updated on Aug 11, 2021, 4:52 PM UTC (d04ecd3)">Diff</a>