### PR TITLE
Can we define party by accountability, not ownership?

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@ intellectual or psychological impairment, or refugees.
 ## The Parties {#parties}
 
 A <dfn>party</dfn> is a [=person=], a legal entity, or a set of legal entities that
-share common owners, common controllers, and a group identity that is readily evident to
+share legal accountability for use of data, common controllers, and a group identity that is readily evident to
 the [=user=] without them needing to consult additional material, typically through
 common branding.
 


### PR DESCRIPTION
It is possible for the same "company" that is ultimately owned by the same stockholders to be more than one party for purposes of being accountable for user data.

There are situations where the same company's web properties in different countries do have common ownership, but users in one jurisdiction are party to a EULA with one subsidiary and users in another jurisdiction have a EULA with a different entity.

From a user point of view the top level owner does not matter as much as whatever legal requirements the "party" is subject to for how their data is used.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/32.html" title="Last updated on Aug 5, 2021, 7:33 PM UTC (b5d6323)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/32/a1c497f...b5d6323.html" title="Last updated on Aug 5, 2021, 7:33 PM UTC (b5d6323)">Diff</a>