### PR TITLE
Add Singling Out and Profiling to the high level threats.

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,8 +569,8 @@ default, [=user agents=] define a <dfn>machine-enforceable context</dfn> or <dfn
 * A set of [=environments=] (roughly iframes (including cross-site iframes), workers, and top-level
   pages)
 * whose [=environment/top-level origins=] are in the [=same site=] (but see [[PSL-PROBLEMS]])
-* being visited within the same user agent installation (and profile for user agents that support
-  multiple profiles)
+* being visited within the same user agent installation (and browser profile for user agents that
+  support multiple browser profiles)
 * between points in time that the user or their agent clears that [=site=]'s cookies and other
   storage (which is sometimes automatic at the end of each session).
 

--- a/index.html
+++ b/index.html
@@ -866,7 +866,7 @@ data-cite="RFC6973#section-5.2.1">RFC6973§5.2.1</a>.
 
 <dt><dfn>Profiling</dfn></dt>
 
-<dd>The processing of data to infer, evaluate or predict an individual's attributes, interests or
+<dd>The inference, evaluation, or prediction of an individual's attributes, interests, or
 behaviours.</dd>
 
 <dt><dfn>Identification</dfn>

--- a/index.html
+++ b/index.html
@@ -871,14 +871,11 @@ behaviours.</dd>
 
 <dt><dfn>Identification</dfn>
 
-<dd> Identification is the linking of information to a particular individual to
-    infer an individual’s identity or to allow the inference of an individual’s
-    identity. See <a
-data-cite="RFC6973#section-5.2.2">RFC6973§5.2.2</a>.
-
-<dt><dfn>Singling Out</dfn></dt>
-
-<dd>The ability to single out an individual from a population or group of individuals.</dd>
+<dd>Identification is the linking of information to a particular individual, even if the information
+isn't linked to that individual's real-world identity (e.g. their legal name, address, government ID
+number, etc.). Identifying someone allows a system to treat them differently from others, which can
+be [=inappropriate=] depending on the [=context=]. See
+<a data-cite="RFC6973#section-5.2.2">RFC6973§5.2.2</a>.
 
 <dt><dfn>Secondary Use</dfn>
 

--- a/index.html
+++ b/index.html
@@ -830,9 +830,7 @@ the funds would be used to support enhanced security for all.
 User agents should attempt to defend their users from a variety of high-level
 threats or attacker goals, described in this section.
 
-[[RFC6973]] describes the following high-level privacy threats, which the TAG
-has adopted into the <a data-cite="security-privacy-questionnaire#threats">
-Security and Privacy Self-Review Questionnaire</a>:
+These threats are an extension of the ones discussed by [[RFC6973]].
 
 <dl>
 <dt><dfn>Surveillance</dfn>
@@ -841,9 +839,9 @@ Security and Privacy Self-Review Questionnaire</a>:
 communications or activities. See <a
 data-cite="RFC6973#section-5.1.1">RFC6973§5.1.1</a>.
 
-<dt><dfn>Stored Data Compromise</dfn>
+<dt><dfn>Data Compromise</dfn>
 
-<dd> End systems that do not take adequate measures to secure stored data from
+<dd> End systems that do not take adequate measures to secure data from
     unauthorized or inappropriate access. See <a
     data-cite="RFC6973#section-5.1.2">RFC6973§5.1.2</a>.
 
@@ -866,12 +864,21 @@ data-cite="RFC6973#section-5.1.4">RFC6973§5.1.4</a>.
     <a
 data-cite="RFC6973#section-5.2.1">RFC6973§5.2.1</a>.
 
+<dt><dfn>Profiling</dfn></dt>
+
+<dd>The processing of data to infer, evaluate or predict an individual's attributes, interests or
+behaviours.</dd>
+
 <dt><dfn>Identification</dfn>
 
 <dd> Identification is the linking of information to a particular individual to
     infer an individual’s identity or to allow the inference of an individual’s
     identity. See <a
 data-cite="RFC6973#section-5.2.2">RFC6973§5.2.2</a>.
+
+<dt><dfn>Singling Out</dfn></dt>
+
+<dd>The ability to single out an individual from a population or group of individuals.</dd>
 
 <dt><dfn>Secondary Use</dfn>
 


### PR DESCRIPTION
Also broaden Data Compromise to include non-stored data.

Fixes #27.


We might instead want to modify Correlation and Identification to include these
threats.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#principles
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/37.html#principles" title="Last updated on Sep 1, 2021, 5:12 PM UTC (0c3fccc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/37/9bf9bae...jyasskin:0c3fccc.html" title="Last updated on Sep 1, 2021, 5:12 PM UTC (0c3fccc)">Diff</a>