### PR TITLE
Make a "party" a single legal entity, not a set.

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@ intellectual or psychological impairment, or refugees.
 
 ## The Parties {#parties}
 
-A <dfn>party</dfn> is a [=person=] or a legal entity.
+A <dfn>party</dfn> is a [=person=] or other legal entity.
 
 The <dfn data-lt="first parties">first party</dfn> is a [=party=] with which the [=user=] intends to
 interact. Merely hovering over, muting, pausing, or closing a given piece of content does

--- a/index.html
+++ b/index.html
@@ -346,10 +346,7 @@ intellectual or psychological impairment, or refugees.
 
 ## The Parties {#parties}
 
-A <dfn>party</dfn> is a [=person=], a legal entity, or a set of legal entities that
-share common owners, common controllers, and a group identity that is readily evident to
-the [=user=] without them needing to consult additional material, typically through
-common branding.
+A <dfn>party</dfn> is a [=person=] or a legal entity.
 
 The <dfn data-lt="first parties">first party</dfn> is a [=party=] with which the [=user=] intends to
 interact. Merely hovering over, muting, pausing, or closing a given piece of content does


### PR DESCRIPTION
This diverges from the https://www.w3.org/TR/tracking-dnt/ definition, which
does allow sets of legal entities to be a single party. These principles are
instead moving toward an approach where multiple parties can be
considered first party as long as they meet conditions like the ones deleted in
this change, which should satisfy the reasons DNT allowed multiple entities to
group into a single party.

This would make #32 unnecessary. Contributes to #26.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#parties
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/43.html#parties" title="Last updated on Sep 1, 2021, 6:44 PM UTC (23a4e1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/43/4d3d266...jyasskin:23a4e1e.html" title="Last updated on Sep 1, 2021, 6:44 PM UTC (23a4e1e)">Diff</a>