### PR TITLE
Improve the style of the one graf in Definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,8 +277,8 @@ understanding is that the law is a floor, not a ceiling.
 
 # Definitions {#definitions}
 
-This section provides a number of elementary building blocks from which to establish a
-shared understanding of privacy. Some of the definitions below build atop the work in
+This section provides a number of building blocks to create a shared understanding of
+privacy. Some of the definitions below build on top of the work in
 <em>Tracking Preference Expression (DNT)</em> [[tracking-dnt]].
 
 ## People &amp; Data {#people-data}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/57.html" title="Last updated on Oct 6, 2021, 4:02 PM UTC (1452eb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/57/ace2c5a...1452eb5.html" title="Last updated on Oct 6, 2021, 4:02 PM UTC (1452eb5)">Diff</a>