### PR TITLE
Remove "out of band"

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,7 +516,7 @@ monitoring of their behaviour. Its <dfn>user agent duties</dfn> include
     time. This is almost never when the [=user=] is trying to do something else such as
     read a page or activate a feature. The duty of honesty goes well beyond that of
     transparency that is often included in older privacy regimes. Unlike transparency, honesty
-    can't hide relevant information in complex out-of-band legal notices and it can't rely on
+    can't hide relevant information in complex legal notices and it can't rely on
     very short summaries provided in a consent dialog.
     If the user has provided [=consent=] to [=processing=] of their [=personal data=],
     the [=user agent=] should inform the user of ongoing [=processing=], with a


### PR DESCRIPTION
Shorten a sentence that applies to all legal notices, not just
out of band ones.

Refs #64


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/67.html" title="Last updated on Oct 13, 2021, 11:23 PM UTC (5cb4ca9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/67/3f2c8c8...5cb4ca9.html" title="Last updated on Oct 13, 2021, 11:23 PM UTC (5cb4ca9)">Diff</a>