### PR TITLE
Remove the Vegas Rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,13 +402,13 @@ A <dfn>service provider</dfn> or <dfn>data processor</dfn> is considered to be t
 A <dfn>data controller</dfn> is a [=party=] that determines the [=means=] and [=purposes=]
 of data processing. Any [=party=] that is not a [=service provider=] is a [=data controller=].
 
-The <dfn>Vegas Rule</dfn> is a simple implementation of privacy in which "<em>what happens
-with the [=first party=] stays with the [=first party=]</em>." Put differently, it
-describes a situation in which the [=first party=] is the only [=data controller=]. Note
-that, while enforcing the [=Vegas Rule=] provides a rule of thumb describing a necessary
-baseline for [=appropriate=] [=data processing=], it is not always sufficient to guarantee
-[=appropriate=] [=processing=] since the [=first party=] can [=process=] data
-[=inappropriately=].
+The <dfn>Vegas Rule</dfn> is a simple implementation of privacy in which "<em>what happens with the
+[=first party=] stays with the [=first party=]</em>." Put differently, it describes a situation in
+which the [=first party=] is the only [=data controller=]. While the [=Vegas Rule=] is a good
+guideline, it's neither necessary nor sufficient for [=appropriate=] [=data processing=]. A [=first
+party=] that maintains exclusive access to a person's data can still [=process=] it
+[=inappropriately=], and there are cases where a third party can learn information about a person
+but still treat it [=appropriately=].
 
 # Acting on Data {#acting-on-data}
 

--- a/index.html
+++ b/index.html
@@ -402,7 +402,15 @@ A <dfn>service provider</dfn> or <dfn>data processor</dfn> is considered to be t
 A <dfn>data controller</dfn> is a [=party=] that determines the [=means=] and [=purposes=]
 of data processing. Any [=party=] that is not a [=service provider=] is a [=data controller=].
 
-## Acting on Data {#acting-on-data}
+The <dfn>Vegas Rule</dfn> is a simple implementation of privacy in which "<em>what happens with the
+[=first party=] stays with the [=first party=]</em>." Put differently, the [=Vegas Rule=] is followed
+when the [=first party=] is the only [=data controller=]. While the [=Vegas Rule=] is a good
+guideline, it's neither necessary nor sufficient for [=appropriate=] [=data processing=]. A [=first
+party=] that maintains exclusive access to a person's data can still [=process=] it
+[=inappropriately=], and there are cases where a third party can learn information about a person
+but still treat it [=appropriately=].
+
+# Acting on Data {#acting-on-data}
 
 A [=party=] <dfn data-lt="process|processing|processed|data processing">processes</dfn> data if it
 carries out operations on [=personal data=], whether or not by automated means, such as
@@ -711,7 +719,8 @@ three privacy tiers:
     and the [=processing=] that a [=person=] can expect without having triggered any
     mechanisms to change their preferences. The exact details for this tier require clear
     definition, including aspects such as data retention, but [=data=] would have to be
-    systematically siloed by [=context=] (<em>not</em> just by [=party=]). This default tier
+    systematically siloed by [=context=] (<em>not</em> by [=party=], making it stricter than
+    the [=Vegas Rule=] and more in line with respecting [=privacy=]). This default tier
     should also be defined differently for certain kinds of [=contexts=]. The legitimate
     [=processing=] that can take place in this tier derives its legitimacy from matching the
     expectations and interests of both the [=person=] and the [=first party=] they're interacting with

--- a/index.html
+++ b/index.html
@@ -403,8 +403,8 @@ A <dfn>data controller</dfn> is a [=party=] that determines the [=means=] and [=
 of data processing. Any [=party=] that is not a [=service provider=] is a [=data controller=].
 
 The <dfn>Vegas Rule</dfn> is a simple implementation of privacy in which "<em>what happens with the
-[=first party=] stays with the [=first party=]</em>." Put differently, it describes a situation in
-which the [=first party=] is the only [=data controller=]. While the [=Vegas Rule=] is a good
+[=first party=] stays with the [=first party=]</em>." Put differently, the [=Vegas Rule=] is followed
+when the [=first party=] is the only [=data controller=]. While the [=Vegas Rule=] is a good
 guideline, it's neither necessary nor sufficient for [=appropriate=] [=data processing=]. A [=first
 party=] that maintains exclusive access to a person's data can still [=process=] it
 [=inappropriately=], and there are cases where a third party can learn information about a person

--- a/index.html
+++ b/index.html
@@ -402,15 +402,7 @@ A <dfn>service provider</dfn> or <dfn>data processor</dfn> is considered to be t
 A <dfn>data controller</dfn> is a [=party=] that determines the [=means=] and [=purposes=]
 of data processing. Any [=party=] that is not a [=service provider=] is a [=data controller=].
 
-The <dfn>Vegas Rule</dfn> is a simple implementation of privacy in which "<em>what happens with the
-[=first party=] stays with the [=first party=]</em>." Put differently, the [=Vegas Rule=] is followed
-when the [=first party=] is the only [=data controller=]. While the [=Vegas Rule=] is a good
-guideline, it's neither necessary nor sufficient for [=appropriate=] [=data processing=]. A [=first
-party=] that maintains exclusive access to a person's data can still [=process=] it
-[=inappropriately=], and there are cases where a third party can learn information about a person
-but still treat it [=appropriately=].
-
-# Acting on Data {#acting-on-data}
+## Acting on Data {#acting-on-data}
 
 A [=party=] <dfn data-lt="process|processing|processed|data processing">processes</dfn> data if it
 carries out operations on [=personal data=], whether or not by automated means, such as
@@ -719,8 +711,7 @@ three privacy tiers:
     and the [=processing=] that a [=person=] can expect without having triggered any
     mechanisms to change their preferences. The exact details for this tier require clear
     definition, including aspects such as data retention, but [=data=] would have to be
-    systematically siloed by [=context=] (<em>not</em> by [=party=], making it stricter than
-    the [=Vegas Rule=] and more in line with respecting [=privacy=]). This default tier
+    systematically siloed by [=context=] (<em>not</em> just by [=party=]). This default tier
     should also be defined differently for certain kinds of [=contexts=]. The legitimate
     [=processing=] that can take place in this tier derives its legitimacy from matching the
     expectations and interests of both the [=person=] and the [=first party=] they're interacting with


### PR DESCRIPTION
The only place that mentions it does so to say that it's *not* invoking the Vegas Rule, so we can shorten the document by just leaving it out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#parties
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/77.html#parties" title="Last updated on Dec 1, 2021, 5:13 PM UTC (e5b5cc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/77/4056f53...jyasskin:e5b5cc7.html" title="Last updated on Dec 1, 2021, 5:13 PM UTC (e5b5cc7)">Diff</a>