### PR TITLE
Allow UA behavior that only indirectly benefits the user.

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@ monitoring of their behaviour. Its <dfn>user agent duties</dfn> include
   <dd>
     Because the [=user agent=] is a [=trustworthy agent=], it is held to be loyal to the
     [=person=] using it in all situations, including in preference to the [=user agent=]'s implementer.
-    When a [=user agent=] carries out [=processing=] that is not directly in the [=person=]'s
+    When a [=user agent=] carries out [=processing=] that is not in the [=person=]'s
     interest but instead benefits another entity (such as the user agent's implementer) that behaviour is
     known as <dfn>self-dealing</dfn>. Behaviour can be [=self-dealing=] even if it is done at the
     same time as [=processing=] that is in the [=person=]'s interest. [=Self-dealing=] is always


### PR DESCRIPTION
In particular, crash reporting, use counters, and similar telemetry only
benefit users in aggregate, which doesn't satisfy the original wording here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#dfn-duty-of-loyalty
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/78.html#dfn-duty-of-loyalty" title="Last updated on Nov 5, 2021, 4:42 AM UTC (74d4ed4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/78/75e1d19...jyasskin:74d4ed4.html" title="Last updated on Nov 5, 2021, 4:42 AM UTC (74d4ed4)">Diff</a>