### PR TITLE
Say that careful cross-context data sharing can be appropriate.

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,16 +473,19 @@ We define <dfn>privacy</dfn> as a right to [=appropriate=] [=data processing=]. 
 
 Note that a [=first party=] can be comprised of multiple [=contexts=] if it is large
 enough that [=people=] would interact with it for more than one [=purpose=]. [=Sharing=]
-[=personal data=] across [=contexts=] is, in the overwhelming majority of cases,
-[=inappropriate=].
+[=personal data=] across [=contexts=] is only [=appropriate=] if the subsequent
+use of that data follows the [=norms=] of the context in which the data was collected.
 
 <div class="example">
 
 Your cute little pup uses <em>Poodle Naps</em> to find comfortable places to snooze,
 and <em>Poodle Fetch</em> to locate the best sticks. Napping and fetching are different
 [=contexts=] with different norms, and sharing data between these contexts is a
-[=privacy violation=] despite the shared ownership of <em>Naps</em> and <em>Fetch</em>
-by the <em>Poodle</em> conglomerate.
+[=privacy violation=] if data collected while napping is used in a way that violates
+napping norms or data collected while fetching is used in a way that violates fetching
+norms. That's true even though <em>Naps</em> and <em>Fetch</em> are both owned by the
+<em>Poodle</em> conglomerate, and even if the data use follows the norms of the context
+in which it's used.
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -474,18 +474,18 @@ We define <dfn>privacy</dfn> as a right to [=appropriate=] [=data processing=]. 
 Note that a [=first party=] can be comprised of multiple [=contexts=] if it is large
 enough that [=people=] would interact with it for more than one [=purpose=]. [=Sharing=]
 [=personal data=] across [=contexts=] is only [=appropriate=] if the subsequent
-use of that data follows the [=norms=] of the context in which the data was collected.
+use of that data follows the [=norms=] of both the context in which the data was
+collected and the context in which it is used.
 
 <div class="example">
 
 Your cute little pup uses <em>Poodle Naps</em> to find comfortable places to snooze,
 and <em>Poodle Fetch</em> to locate the best sticks. Napping and fetching are different
 [=contexts=] with different norms, and sharing data between these contexts is a
-[=privacy violation=] if data collected while napping is used in a way that violates
-napping norms or data collected while fetching is used in a way that violates fetching
-norms. That's true even though <em>Naps</em> and <em>Fetch</em> are both owned by the
-<em>Poodle</em> conglomerate, and even if the data use follows the norms of the context
-in which it's used.
+[=privacy violation=] if data shared between napping and fetching is used in a way that
+violates either the napping or fetching norms. That's true even though <em>Naps</em> and
+<em>Fetch</em> are both owned by the <em>Poodle</em> conglomerate, and even if the data
+use follows the norms of just one of the contexts.
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -480,11 +480,12 @@ collected and the context in which it is used.
 <div class="example" id="data-sharing-example">
 
 You share personal data with your bank in the context of managing your money. They would like to
-re-use that data in order to sell you another product, but marketing is a different [=context=] from
-banking, so using your data in this way is usually a [=privacy violation=].
+re-use that data in order to help another merchant sell you a product based on the purchase history
+the bank can see. Since marketing is a different [=context=] from banking, using your data in this
+way is usually a [=privacy violation=].
 
-In some cases, the other product might solve a money management problem, and even be the fiduciarily
-correct thing to recommend. In those cases, the data use could be [=appropriate=].
+If instead the bank is recommending a product to help your financial affairs, this may be an
+[=appropriate=] use of data, or even a use within the original [=context=].
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -477,7 +477,7 @@ enough that [=people=] would interact with it for more than one [=purpose=]. [=S
 use of that data follows the [=norms=] of both the context in which the data was
 collected and the context in which it is used.
 
-<div class="example">
+<div class="example" id="data-sharing-example">
 
 You share personal data with your bank in the context of managing your money. They would like to
 re-use that data in order to sell you another product, but marketing is a different [=context=] from

--- a/index.html
+++ b/index.html
@@ -479,13 +479,12 @@ collected and the context in which it is used.
 
 <div class="example">
 
-Your cute little pup uses <em>Poodle Naps</em> to find comfortable places to snooze,
-and <em>Poodle Fetch</em> to locate the best sticks. Napping and fetching are different
-[=contexts=] with different norms, and sharing data between these contexts is a
-[=privacy violation=] if data shared between napping and fetching is used in a way that
-violates either the napping or fetching norms. That's true even though <em>Naps</em> and
-<em>Fetch</em> are both owned by the <em>Poodle</em> conglomerate, and even if the data
-use follows the norms of just one of the contexts.
+You share personal data with your bank in the context of managing your money. They would like to
+re-use that data in order to sell you another product, but marketing is a different [=context=] from
+banking, so using your data in this way is usually a [=privacy violation=].
+
+In some cases, the other product might solve a money management problem, and even be the fiduciarily
+correct thing to recommend. In those cases, the data use could be [=appropriate=].
 
 </div>
 


### PR DESCRIPTION
My thought here is that offline data sharing between contexts, even contexts with very different norms, happens all the time, and the people who do it are just careful to avoid breaking the norms of the context they got the data from. Online, the norms of two different contexts could easily be similar enough to allow a lot of cross-context use without breaking any user expectations or preferences.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#contexts-and-privacy
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/80.html#contexts-and-privacy" title="Last updated on Nov 24, 2021, 5:31 PM UTC (b464961)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/80/4056f53...jyasskin:b464961.html" title="Last updated on Nov 24, 2021, 5:31 PM UTC (b464961)">Diff</a>