### PR TITLE
Remove leftover caption from meme

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,13 +656,6 @@ Reference to the [=FIPs=] survives to this day. They are often referenced as <em
 and choice</em>, which, in today's digital environment, is often a strong indication that
 [=inappropriate=] [=processing=] is being described.
 
-<figure>
-<img src="agnes-tc.jpg" alt="Agnes from Wandavision winking 'Transparency and choice'">
-<figcaption>
-  A method of privacy regulation which promises honesty and autonomy but delivers neither.
-  [[?CONFIDING]].
-</figcaption>
-</figure>
 
 # Opt-in, Consent, Opt-out, Global Controls {#opt-in-out}
 


### PR DESCRIPTION
This caption does not appear to make sense without the original meme
image.  Save for the meme version of this document.

Refs #58


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/82.html" title="Last updated on Nov 10, 2021, 3:49 PM UTC (b76b4a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/82/93f2357...b76b4a3.html" title="Last updated on Nov 10, 2021, 3:49 PM UTC (b76b4a3)">Diff</a>