### PR TITLE
Change "about" back to "related to" in definition of "personal data".

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,7 +798,7 @@ of an event that occurs nearly-simultaneously on both sites.
 ## Data {#data}
 
 We define <dfn data-lt="data">personal data</dfn> as any information that is directly or
-indirectly about an identified or identifiable [=person=], such as by reference to an
+indirectly related to an identified or identifiable [=person=], such as by reference to an
 [=identifier=] ([[GDPR]], [[OECD-GUIDELINES]], [[CONVENTION-108]]).
 
 If a [=person=] could reasonably be identified or re-identified when [=data=] is combined with other


### PR DESCRIPTION
Should fix the first comment in #92, per today's meeting. Did I get this right? 

cc @mnot


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/99.html" title="Last updated on Jan 12, 2022, 8:27 PM UTC (e73221c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/99/36e9b27...jyasskin:e73221c.html" title="Last updated on Jan 12, 2022, 8:27 PM UTC (e73221c)">Diff</a>