### PR TITLE
Example of an information sharing norm

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,8 +456,8 @@ cocktail party is more open. Information about what a person searches or shops f
 be used to improve their future search results, but shouldn't be used to affect a job
 application or even to gossip with their neighbors. Information about where a person is
 trying to go can be used to help them get there, but not to tell their partner they're
-cheating. Interruptions from chat partners are expected, but flashing ads and
-notifications about irrelevant products aren't.
+cheating.  Automatic suggestions of names of co-workers and friends are expected on messaging
+or collaboration sites, but suggestion of the names of people who rode the same bus are not.
 
 </aside>
 


### PR DESCRIPTION
Use an example that makes it clear that the concern is information usage norms, not just annoying user experience.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/100.html" title="Last updated on Jan 12, 2022, 8:38 PM UTC (bad1d48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/100/36e9b27...bad1d48.html" title="Last updated on Jan 12, 2022, 8:38 PM UTC (bad1d48)">Diff</a>