### PR TITLE
Add a w3c group (tag) to the document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     // All config options at https://respec.org/docs/
     var respecConfig = {
       specStatus: 'editor-draft-finding',
+      group: 'tag',
       isPreview: true,
       format: 'markdown',
       editors: [{


### PR DESCRIPTION
Respec now requires this in order to use W3C styles, since
https://github.com/w3c/respec/pull/3979.

Please double-check that it actually makes sense to mark this as a TAG
document.

The other respec error is filed as https://github.com/w3c/respec/issues/3994.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/117.html" title="Last updated on Jan 31, 2022, 8:08 PM UTC (7da117d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/117/a19b13e...jyasskin:7da117d.html" title="Last updated on Jan 31, 2022, 8:08 PM UTC (7da117d)">Diff</a>