### PR TITLE
include warning about how principles aren't done

### DIFF
--- a/index.html
+++ b/index.html
@@ -661,6 +661,12 @@ is that a [=context=] is not defined in terms of who owns it (it is not a [=part
 [=data=] between different [=contexts=] of a single company is just as much a [=privacy violation=] as
 if the same data were shared between unrelated [=parties=].
 
+<aside class="issue">
+  Please note that the initial focus of this draft was on <a href="#intro"></a>. This section is
+  incomplete and less mature. The absence of a specific principle should not be seen as an
+  indication that the Task Force considers it to be of lesser importance.
+</aside>
+
 ## Principles for Identity on the Web {#identity}
 
 <aside class="issue">


### PR DESCRIPTION
During the last call we discussed the fact that we could message to readers the idea that the Principles section wasn't as baked but that that shouldn't be read as indicating that we don't care about one thing or another. If we do go ahead, I'd suggest something like the below.