### PR TITLE
Find the h2 inside the bp-summary.

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             prac.classList.remove('advisement');
             prac.classList.add('principle');
           }
-          let h2 = document.querySelector('#bp-summary > h2');
+          let h2 = document.querySelector('#bp-summary h2');
           h2.innerHTML = h2.innerHTML.replace('Best Practices Summary', 'Principles Summary');
         }
       ],


### PR DESCRIPTION
Respec added a markup layer between the section and the h2...


@darobin, did I get the fix right?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/125.html" title="Last updated on Feb 9, 2022, 6:03 PM UTC (f580632)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/125/f96eaf2...jyasskin:f580632.html" title="Last updated on Feb 9, 2022, 6:03 PM UTC (f580632)">Diff</a>