### PR TITLE
expanding section on data rights

### DIFF
--- a/index.html
+++ b/index.html
@@ -945,36 +945,57 @@ Note that [=controlled de-identified data=], on its own, is not sufficient to re
 
 ### Rights {#data-rights}
 
-[=People=] retain certain rights over data about themselves, and these rights should be facilitated by their [=user agent=] and the [=parties=]. While data rights alone are not sufficient to support [=privacy=], they do support self-determination and help improve accountability. Such rights include:
+[=People=] retain certain rights over data about themselves, and these rights should be facilitated
+by their [=user agent=] and the [=parties=] they're interacting with. While data rights alone are
+not sufficient to satisfy all [=privacy=] principles for the Web, they do support self-determination
+and help improve accountability. Such rights include:
 
-* The right to <em>access</em> [=data=] about oneself.
+* The <dfn data-export="">right to access</dfn> [=data=] about oneself.
 
-  This right includes being able to discover data about oneself (no secret databases) and to review what information has been collected or inferred.
+This right includes being able to discover data about oneself (implying no databases are kept
+secret) and to review
+what information has been collected or inferred.
 
-* The right to <em>erase</em> [=data=] about oneself, sometimes described as a <em>right to be forgotten</em>. 
+* The <dfn data-export="" data-lt="right to be forgotten">right to erase</dfn> [=data=] about
+oneself, sometimes described as a <em>right to be forgotten</em>.
 
-  The right to erase applies whether or not terminating use of a service altogether, though what [=data=] can be erased may differ between those two cases. On the Web, [=people=] may wish to erase data on their device, on a server, or both, and the distinctions may not always be clear.
+The right to erase applies whether or not terminating use of a service altogether, though what
+[=data=] can be erased may differ between those two cases. On the Web, [=people=] may wish to erase
+data on their device, on a server, or both, and the distinctions may not always be clear.
 
-* The right to <em>port</em> [=data=], including data one has stored with a [=party=], so it can easily be reused or transferred elsewhere.
+* The <dfn data-export="" data-lt="right to portability" data-local-lt="portability">right to
+port</dfn> [=data=], including data one has stored with a [=party=], so it can easily be reused or
+transferred elsewhere.
 
-  Portability is needed to realize the ability for [=people=] to make choices about services with different data practices. Standards for interoperability are essential for effective re-use.
+Portability is needed to realize the ability for [=people=] to make choices about services with
+different data practices. Standards for interoperability are essential for effective re-use.
 
-* The right to <em>correct</em> [=data=] about oneself, to ensure that one's [=identity=] is
-  properly reflected in a system.
+* The <dfn data-export="">right to correct</dfn> [=data=] about oneself, to ensure that one's
+[=identity=] is properly reflected in a system.
 
-* The right to <em>be free from automated decision-making</em> based on data about oneself.
+* The <dfn data-export="">right to be free from automated decision-making</dfn> based on [=data=]
+about oneself.
 
-  For some kinds of decision-making with substantial consequences, there is a privacy interest in being able to exclude oneself from automated profiling.
+For some kinds of decision-making with substantial consequences, there is a privacy interest in
+being able to exclude oneself from automated profiling. For example, some services may alter the
+price of products (price discrimination) or offers for credit or insurance based on [=data=]
+collected about a person. Those alterations may be consequential (financially, say) and
+objectionable to people who believe those decisions based on data about them are inaccurate or
+unjust. As another example, some services may draw inferences about a user's identity, humanity or
+presence based on facial recognition algorithms run on camera data. Because facial recognition
+algorithms and training sets are fallible and may exhibit certain biases, people may not wish to
+submit to decisions based on that kind of automated recognition.
 
-  <aside class="issue">
-    Should we settle on examples of the kind of automated decision-making that is impactful enough that one can opt out of it? Are there direct ways to apply this to the Web generally?
-  </aside>  
+* The <dfn data-export=""
+  data-lt="right to object|right to withdraw consent|right to restrict use">right to object,
+withdraw consent, and restrict use</dfn> of data about oneself.
 
-* The right to <em>object, withdraw consent and restrict use</em> of data about oneself.
+[=People=] may change their decisions about consent or may object to subsequent uses of data about
+themselves. Retaining rights requires ongoing control, not just at the time of collection.
 
-  [=People=] may change their decisions about consent, or may object to subsequent uses of data about themselves. Retaining rights requires ongoing control, not just at the time of collection.
-
-The legal rights of [=people=] as data subjects are found within the OECD Privacy Principles [[OECD-Guidelines]], [[Records-Computers-Rights]] and the [[GDPR]], among other places. These participatory rights by people over data about themselves are inherent to [=autonomy=]. 
+The OECD Privacy Principles [[OECD-Guidelines]], [[Records-Computers-Rights]], and the [[GDPR]],
+among other places, include many of the rights [=people=] have as data subjects. These participatory
+rights by people over data about themselves are inherent to [=autonomy=].
 
 ## Principles for Sensitive Information {#hl-sensitive-information}
 

--- a/index.html
+++ b/index.html
@@ -964,9 +964,15 @@ Note that [=controlled de-identified data=], on its own, is not sufficient to re
 
 * The right to <em>be free from automated decision-making</em> based on data about oneself.
 
+  For some kinds of decision-making with substantial consequences, there is a privacy interest in being able to exclude oneself from automated profiling.
+
+  <aside class="issue">
+    Should we settle on examples of the kind of automated decision-making that is impactful enough that one can opt out of it? Are there direct ways to apply this to the Web generally?
+  </aside>  
+
 * The right to <em>object, withdraw consent and restrict use</em> of data about oneself.
 
-  [=People=] may change their decisions about consent, or may object to subsequent uses of data about themselves
+  [=People=] may change their decisions about consent, or may object to subsequent uses of data about themselves. Retaining rights requires ongoing control, not just at the time of collection.
 
 The legal rights of [=people=] as data subjects are found within the OECD Privacy Principles [[OECD-Guidelines]], [[Records-Computers-Rights]] and the [[GDPR]], among other places. These participatory rights by people over data about themselves are inherent to [=autonomy=]. 
 

--- a/index.html
+++ b/index.html
@@ -956,8 +956,7 @@ This right includes being able to discover data about oneself (implying no datab
 secret) and to review
 what information has been collected or inferred.
 
-* The <dfn data-export="" data-lt="right to be forgotten">right to erase</dfn> [=data=] about
-oneself, sometimes described as a <em>right to be forgotten</em>.
+* The <dfn data-export="" data-lt="right to erase">right to erase</dfn> [=data=] about oneself.
 
 The right to erase applies whether or not terminating use of a service altogether, though what
 [=data=] can be erased may differ between those two cases. On the Web, [=people=] may wish to erase

--- a/index.html
+++ b/index.html
@@ -282,6 +282,11 @@
           href: 'https://global.oup.com/academic/product/why-privacy-matters-9780190939045?cc=us&lang=en&',
           publisher: 'Oxford University Press',
         },
+        'Records-Computers-Rights': {
+          title: 'Records, Computers and the Rights of Citizens',
+          publisher: 'U.S. Department of Health, Education & Welfare',
+          href: 'https://archive.epic.org/privacy/hew1973report/'
+        }
       },
     };
   </script>
@@ -566,7 +571,7 @@ TAG's resolution on a [Strong and Secure Web Platform](https://www.w3.org/blog/2
 to ensure that "<i>broad testing and audit continues to be possible</i>" where
 [=information flows=] and automated decisions are involved.
 
-Such transparency can only function if there are strong rights of access to data (including data
+Such transparency can only function if there are strong [rights](#data-rights) of access to data (including data
 derived from one's personal data) as well as mechanisms to explain the outcomes of automated
 decisions.
 
@@ -940,18 +945,30 @@ Note that [=controlled de-identified data=], on its own, is not sufficient to re
 
 ### Rights {#data-rights}
 
-To the extent possible, [=people=] should retain a certain number of rights over their data, and
-these rights should be facilitated by the [=parties=]. While data rights are a self-governing
-mechanism that is not sufficient to support [=privacy=], they do complement self-determination and
-help improve accountability. Such rights should include:
+[=People=] retain certain rights over data about themselves, and these rights should be facilitated by their [=user agent=] and the [=parties=]. While data rights alone are not sufficient to support [=privacy=], they do support self-determination and help improve accountability. Such rights include:
 
 * The right to <em>access</em> [=data=] about oneself.
-* The right to <em>erase</em> [=data=] about oneself, with or without terminating the service (though
-  what [=data=] can be erased may differ between those two cases).
-* The right to <em>port</em> information that one has stored with a given [=party=] in such a way
-  that it can easily be reused or transferred elsewhere.
+
+  This right includes being able to discover data about oneself (no secret databases) and to review what information has been collected or inferred.
+
+* The right to <em>erase</em> [=data=] about oneself, sometimes described as a <em>right to be forgotten</em>. 
+
+  The right to erase applies whether or not terminating use of a service altogether, though what [=data=] can be erased may differ between those two cases. On the Web, [=people=] may wish to erase data on their device, on a server, or both, and the distinctions may not always be clear.
+
+* The right to <em>port</em> [=data=], including data one has stored with a [=party=], so it can easily be reused or transferred elsewhere.
+
+  Portability is needed to realize the ability for [=people=] to make choices about services with different data practices. Standards for interoperability are essential for effective re-use.
+
 * The right to <em>correct</em> [=data=] about oneself, to ensure that one's [=identity=] is
   properly reflected in a system.
+
+* The right to <em>be free from automated decision-making</em> based on data about oneself.
+
+* The right to <em>object, withdraw consent and restrict use</em> of data about oneself.
+
+  [=People=] may change their decisions about consent, or may object to subsequent uses of data about themselves
+
+The legal rights of [=people=] as data subjects are found within the OECD Privacy Principles [[OECD-Guidelines]], [[Records-Computers-Rights]] and the [[GDPR]], among other places. These participatory rights by people over data about themselves are inherent to [=autonomy=]. 
 
 ## Principles for Sensitive Information {#hl-sensitive-information}
 


### PR DESCRIPTION
Expanding on a list of generally accepted data rights (or subject data rights) from various laws and earlier reports. Provided some context or explanation for each. Added references (including the HEW report, one of the first privacy principles reports).

Open question (marked as such in the text) on a right to be free from automated decision-making of certain kinds (as found in the GDPR, and one of the motivations for FIPPs in the 1970s) -- can we give examples? how does this apply to the Web?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#data-rights
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/136.html#data-rights" title="Last updated on Mar 25, 2022, 4:23 PM UTC (0b41048)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/136/d2fc9ca...0b41048.html" title="Last updated on Mar 25, 2022, 4:23 PM UTC (0b41048)">Diff</a>