### PR TITLE
Modify two instances of "own"

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,7 +780,7 @@ then they sacrifice a proportionate amount of their privacy protections, but
 1. Often the service can only prevent the norm violation by also collecting data from
    innocent users. This extra collection is not always [=appropriate=], especially if it
    allows pervasive monitoring ([[RFC7258]], [[RFC7687]]).
-1. If a service owner wants to collect some extra data, it can be tempting for them to
+1. If a service operator wants to collect some extra data, it can be tempting for them to
    define norms and proportionality that allow them to do so.
 
 The following examples illustrate some of the tensions:
@@ -833,7 +833,7 @@ fully expect more specific [=contexts=] of the Web to add their own [=principles
 
 To the extent possible, [=user agents=] are expected to enforce these [=principles=]. However, this is not
 always possible and additional enforcement mechanisms are needed. One particularly salient issue
-is that a [=context=] is not defined in terms of who owns it (it is not a [=party=]). Sharing
+is that a [=context=] is not defined in terms of who owns or controls it (it is not a [=party=]). Sharing
 [=data=] between different [=contexts=] of a single company is just as much a [=privacy violation=] as
 if the same data were shared between unrelated [=parties=].
 


### PR DESCRIPTION
Trying to make clear that party-ness and ownership (which can be complex) are not necessarily the same.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/144.html" title="Last updated on Apr 14, 2022, 1:54 AM UTC (23a5a30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/144/ff66160...23a5a30.html" title="Last updated on Apr 14, 2022, 1:54 AM UTC (23a5a30)">Diff</a>