### PR TITLE
Allow non-immediate goals in data sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,13 @@
           href: 'https://www.cambridge.org/core/books/governing-privacy-in-knowledge-commons/FA569455669E2CECA25DF0244C62C1A1',
           publisher: 'Cambridge University Press',
         },
+        'Governance-Through-Privacy': {
+          title: "Governance Through Privacy, Fairness, and Respect for Individuals",
+          authors: ['Dixie B. Baker', 'Jane Kaye', 'Sharon F. Terry'],
+          date: '2016-03-31',
+          publisher: "eGEMs",
+          href: 'https://doi.org/10.13063/2327-9214.1207',
+        },
         'GPC': {
           title: 'Global Privacy Control (GPC)',
           authors: ['Robin Berjon', 'Sebastian Zimmeck', 'Ashkan Soltani', 'David Harbage', 'Peter Snyder'],
@@ -1050,12 +1057,14 @@ of an event that occurs nearly-simultaneously on both sites.
 <div class="practice">
 
 <p><span class="practicelab" id="user-agent-data-sharing">
-User agents should only share and present information about the user that
-the user can reasonably anticipate being shared, and which directly relate to the users overt, immediate goals.
+A person's personal information should never be collected, used, transmitted, or disclosed
+in a way that would surprise the person were they to learn about it
+[[Governance-Through-Privacy]]. This information should also be needed for the person's
+goals.</span></p>
+
 User agents and sites should be conservative when deciding if information is related to a users goals; the
 longer the chain of reasoning used to justify data collection, the less likely for that data
 collection to be ethical and principled.
-</span></p>
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -172,13 +172,6 @@
           href: 'https://www.cambridge.org/core/books/governing-privacy-in-knowledge-commons/FA569455669E2CECA25DF0244C62C1A1',
           publisher: 'Cambridge University Press',
         },
-        'Governance-Through-Privacy': {
-          title: "Governance Through Privacy, Fairness, and Respect for Individuals",
-          authors: ['Dixie B. Baker', 'Jane Kaye', 'Sharon F. Terry'],
-          date: '2016-03-31',
-          publisher: "eGEMs",
-          href: 'https://doi.org/10.13063/2327-9214.1207',
-        },
         'GPC': {
           title: 'Global Privacy Control (GPC)',
           authors: ['Robin Berjon', 'Sebastian Zimmeck', 'Ashkan Soltani', 'David Harbage', 'Peter Snyder'],
@@ -1057,10 +1050,8 @@ of an event that occurs nearly-simultaneously on both sites.
 <div class="practice">
 
 <p><span class="practicelab" id="user-agent-data-sharing">
-A person's personal information should never be collected, used, transmitted, or disclosed
-in a way that would surprise the person were they to learn about it
-[[Governance-Through-Privacy]]. This information should also be needed for the person's
-goals.</span></p>
+User agents should only share information about the user that the user can reasonably
+anticipate being shared, and which directly relate to the user's goals.</span></p>
 
 User agents and sites should be conservative when deciding if information is related to a users goals; the
 longer the chain of reasoning used to justify data collection, the less likely for that data


### PR DESCRIPTION
And use wording from a pre-existing document instead of drafting our own. This other wording would cover both sites and browsers, where our wording only covered browsers.

I tweaked their wording to switch user->person and she->they.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#data
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/162.html#data" title="Last updated on May 18, 2022, 4:38 PM UTC (0bd114b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/162/7c922f1...jyasskin:0bd114b.html" title="Last updated on May 18, 2022, 4:38 PM UTC (0bd114b)">Diff</a>