### PR TITLE
add additional characteristics used to identify users

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,9 +884,10 @@ store data about that [=person=]. Examples of [=identifiers=] for a [=person=] c
 * an identification number including those mapping to a device that this [=person=] may be using,
 * their phone number,
 * their location data,
-* an online identifier such as email or IP addresses, or
+* an online identifier such as email or IP addresses,
+* browser fingerprints (based on a combination of configuration characteristics) or
 * factors specific to their physical, physiological, genetic, mental, economic,
-cultural, social, behavioral, or browser [=identity=].
+cultural, social, or behavioral [=identity=].
 
 Strings derived from [=identifiers=], for instance through hashing, are still
 [=identifiers=] so long as they may identify a [=person=].

--- a/index.html
+++ b/index.html
@@ -885,8 +885,7 @@ store data about that [=person=]. Examples of [=identifiers=] for a [=person=] c
 * their phone number,
 * their location data,
 * an online identifier such as email or IP addresses, or
-* factors specific to their physical, physiological, genetic, mental, economic, cultural, or social
-[=identity=].
+* factors specific to their physical, physiological, genetic, mental, economic, cultural, social, behavioral, or browser [=identity=].
 
 Strings derived from [=identifiers=], for instance through hashing, are still
 [=identifiers=] so long as they may identify a [=person=].

--- a/index.html
+++ b/index.html
@@ -885,7 +885,7 @@ store data about that [=person=]. Examples of [=identifiers=] for a [=person=] c
 * their phone number,
 * their location data,
 * an online identifier such as email or IP addresses,
-* browser fingerprints (based on a combination of configuration characteristics) or
+* browser fingerprints (based on a combination of configuration characteristics), or
 * factors specific to their physical, physiological, genetic, mental, economic,
 cultural, social, or behavioral [=identity=].
 

--- a/index.html
+++ b/index.html
@@ -885,7 +885,8 @@ store data about that [=person=]. Examples of [=identifiers=] for a [=person=] c
 * their phone number,
 * their location data,
 * an online identifier such as email or IP addresses, or
-* factors specific to their physical, physiological, genetic, mental, economic, cultural, social, behavioral, or browser [=identity=].
+* factors specific to their physical, physiological, genetic, mental, economic,
+cultural, social, behavioral, or browser [=identity=].
 
 Strings derived from [=identifiers=], for instance through hashing, are still
 [=identifiers=] so long as they may identify a [=person=].


### PR DESCRIPTION
Related to the concept in PR #166 this calls out some less common characteristics which the user doesn't explicitly provide, but which should be accounted for when attempting to produce a private identity for the user when they do not wish to share anything about themselves in particular contexts.

cc @jyasskin since this one will be related to the original issue as well


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kdenhartog/privacy-principles/pull/167.html" title="Last updated on Jun 22, 2022, 4:09 PM UTC (70fa574)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/167/baea919...kdenhartog:70fa574.html" title="Last updated on Jun 22, 2022, 4:09 PM UTC (70fa574)">Diff</a>