### PR TITLE
[overtaken] discussion text for ancillary uses / aggregation e.g. #150

### DIFF
--- a/index.html
+++ b/index.html
@@ -1037,10 +1037,6 @@ of an event that occurs nearly-simultaneously on both sites.
 ## Data minimization {#data}
 
 <aside class="issue">
-  This section has not been edited for narrative.
-</aside>
-
-<aside class="issue">
   There is not currently consensus among the authors and contributors to this document about the below
   principles. Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this
   issue</a>
@@ -1095,7 +1091,23 @@ such a use) and some people would identify those uses as supporting their own go
 Aggregated or <a href="#dfn-de-identified">de-identified</a> data is often more likely to be
 acceptable in these senses and often still contributes to the collective benefit while minimizing
 privacy threats to a particular individual (see <a href="#principle-collective-privacy">collective
-privacy</a>). But some users might also object, in particular instances or in general.
+privacy</a>). But some people might also object, in particular instances or in general.
+
+<aside class="example">
+  Privacy-preserving measurement techniques may be used for aggregate calculations while minimizing
+  the parties that have access to personal data about many individual people. Encryption and
+  privacy-preserving proxies may be used to minimize the parties that have access to personal data or
+  to hide the contents of personal data used for telemetry or other kinds of measurement. But even
+  with those protections, some people may prefer not to participate in some kinds of measurement.
+
+  Ongoing work on privacy-preserving technologies in the <abbr title="Internet Engineering Task
+  Force">IETF</abbr> <a href="https://datatracker.ietf.org/wg/ppm/about/"><abbr
+  title="privacy-preserving measurement">ppm</abbr></a>, <abbr title="Internet Research Task
+  Force">IRTF</abbr> <a href="https://datatracker.ietf.org/rg/pearg/about/"><abbr title="Privacy
+  Enhancements and Assessments Research Group">pearg</abbr></a> and W3C <a
+  href="https://patcg.github.io/"><abbr title="Private Advertising Technology Community
+  Group">PATCG</abbr></a> groups may be relevant. 
+</aside>
 
 <span class="practicelab">Sites and user agents should seek to understand and respect people's goals
 and preferences about use of data about them.</span>

--- a/index.html
+++ b/index.html
@@ -1047,47 +1047,55 @@ of an event that occurs nearly-simultaneously on both sites.
   for more details.
 </aside>
 
-<div class="practice">
+<span class="practicelab">Sites, user agents and other parties should minimize the amount of data
+about people that is shared with or transferred between parties on the Web.</span>
 
-<p><span class="practicelab" id="user-agent-data-sharing">
-User agents should only share and present information about the user that
-the user can reasonably anticipate being shared, and which directly relate to the users overt, immediate goals.
-User agents and sites should be conservative when deciding if information is related to a users goals; the
-longer the chain of reasoning used to justify data collection, the less likely for that data
-collection to be ethical and principled.
-</span></p>
+Data minimization limits the risks of data being disclosed or misused and also makes it possible to
+more meaningfully provide people with understandable decisions about data about them.
 
-</div>
+<span class="practicelab">APIs should be designed to minimize the amount of data that is requested
+and provide granularity and user controls over personal data that is communicated to sites.</span>
 
-Examples:
+<aside class="note">
+This principle is further detailed in the TAG finding on <a
+href="https://www.w3.org/2001/tag/doc/APIMinimization-20100605.html">Data Minimization in Web
+APIs</a>.
+</aside>
 
-* Sharing geo-location data with a map website after a user has clicked a "share my location" button has
-  a small number of "hops" between intent and data.
-* Sharing information about the user's selected DNS resolver with a site, so that the site authors can debug
-  possible issues around tail/uncommon resolvers, has a large number of "hops" between user intent (to do
-  a thing on the website) and collection motivation (users like our site, so users will want to share information
-  with us to help us improve the site).
+In maintaining duties of <a href="#dfn-duty-of-protection">protection</a>, <a
+href="#dfn-duty-of-discretion">discretion</a> and <a href="#dfn-duty-of-loyalty">loyalty</a>, user
+agents should be cautious about sharing data not necessary to satisfy a user's immediate goals.
 
-<div class="practice">
+Data is often shared by user agents even outside the need to load and display a page for uses
+including: 
 
-<p><span class="practicelab" id="sensitive-vs-non-sensitive-data">
-User agents should generally not attempt to distinguish between sensitive and nonsensitive personal data; all
-data and personal information is likely to be sensitive to some users, often in ways unanticipated by
-browser vendors and site operators.
-</span></p>
+* usage reporting of sites or browser features; 
+* debugging site issues; 
+* measuring performance; 
+* detecting security problems or attacks; 
+* software updates; 
+* prefetching content. 
 
-</div>
+In some cases, mechanisms for sharing data are provided in order to minimize some other data
+collection mechanism identified as more intrusive or costly.
 
-<div class="practice">
+For some uses, some people would reasonably anticipate sharing such data and some people would be
+willing to participate (for example, might have explicitly decided to contribute if they had the
+time and understanding to consider details about such a use) and some people would identify those
+uses as supporting their own goals. 
 
-<p><span class="practicelab" id="minimal-data-sharing">
-User agents should always aim to share the minimal amount of information with a site
-that is needed for the user to achieve a user's goals. Data collected today can often be used in
-unanticipated ways in the future to enact privacy harms, even data that seems unlikely to
-be identifying, sensitive or otherwise privacy-harming.
-</span></p>
+Aggregated or <a href="#dfn-de-identified">de-identified</a> data is often more likely to be
+acceptable in these senses and often still contributes to the collective benefit while minimizing
+privacy threats to a particular individual (see <a href="#principle-collective-privacy">collective
+privacy</a>). But some users might also object, in particular instances or in general. In order to
+distinguish these cases, asking people about their goals and preferences is best.
 
-</div>
+<span class="practicelab">Sites and user agents should directly ask people about their goals and
+their preferences about use of data about them.</span>
+
+Because personal data may be sensitive in unexpected ways, or have risks of future uses that could
+be unexpected or harmful, minimization as a principle applies to personal data that is not currently
+known to be identifying, sensitive or otherwise potentially harmful.
 
 ## Sensitive Information {#hl-sensitive-information}
 

--- a/index.html
+++ b/index.html
@@ -1034,16 +1034,16 @@ collecting the same piece of identifying information on both sites, or by correl
 of an event that occurs nearly-simultaneously on both sites.
 
 
-## Personal Data {#data}
+## Data minimization {#data}
 
 <aside class="issue">
   This section has not been edited for narrative.
 </aside>
 
 <aside class="issue">
-  There is not currently consensus among the authors and contributors to this
-  document about the below principles.
-  Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this issue</a>
+  There is not currently consensus among the authors and contributors to this document about the below
+  principles. Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this
+  issue</a>
   for more details.
 </aside>
 
@@ -1053,48 +1053,75 @@ about people that is shared with or transferred between parties on the Web.</spa
 Data minimization limits the risks of data being disclosed or misused and also makes it possible to
 more meaningfully provide people with understandable decisions about data about them.
 
-<span class="practicelab">APIs should be designed to minimize the amount of data that is requested
+<span class="practicelab">Web APIs should be designed to minimize the amount of data that is requested
 and provide granularity and user controls over personal data that is communicated to sites.</span>
 
 <aside class="note">
-This principle is further detailed in the TAG finding on <a
+This principle was further explored in an earlier TAG draft on <a
 href="https://www.w3.org/2001/tag/doc/APIMinimization-20100605.html">Data Minimization in Web
 APIs</a>.
 </aside>
 
 In maintaining duties of <a href="#dfn-duty-of-protection">protection</a>, <a
 href="#dfn-duty-of-discretion">discretion</a> and <a href="#dfn-duty-of-loyalty">loyalty</a>, user
-agents should be cautious about sharing data not necessary to satisfy a user's immediate goals.
+agents should be conservative when sharing data not necessary to satisfy a user's immediate goals.
 
-Data is often shared by user agents even outside the need to load and display a page for uses
-including: 
+On the Web, data is often shared even outside the need to load and display a page for <dfn>ancillary
+uses</dfn> including: 
 
-* usage reporting of sites or browser features; 
-* debugging site issues; 
-* measuring performance; 
-* detecting security problems or attacks; 
-* software updates; 
-* prefetching content. 
+* browser telemetry, including: 
+  * performance measurements, 
+  * measuring feature usage, 
+  * debugging site, browser and networking issues, and, 
+  * detecting security problems or attacks; 
+* site telemetry, including: 
+  * performance measurements, 
+  * analytics about usage and visitors, 
+  * debugging site issues, and, 
+  * detecting security problems or attacks; 
+* advertising and social media sharing, including: 
+  * measurement, targeting, ad auctions, personalization, fraud prevention; 
+* performance, including caching and prefetching content; 
+* software updates.
 
 In some cases, mechanisms for sharing data are provided in order to minimize some other data
 collection mechanism identified as more intrusive or costly.
 
-For some uses, some people would reasonably anticipate sharing such data and some people would be
-willing to participate (for example, might have explicitly decided to contribute if they had the
-time and understanding to consider details about such a use) and some people would identify those
-uses as supporting their own goals. 
+For some uses, some people would reasonably anticipate sharing such data or identify that use as a
+commonly-accepted contextual norm and some people would be willing to participate (for example, might
+have explicitly decided to contribute if they had the time and understanding to consider details about
+such a use) and some people would identify those uses as supporting their own goals. 
 
 Aggregated or <a href="#dfn-de-identified">de-identified</a> data is often more likely to be
 acceptable in these senses and often still contributes to the collective benefit while minimizing
 privacy threats to a particular individual (see <a href="#principle-collective-privacy">collective
-privacy</a>). But some users might also object, in particular instances or in general. In order to
-distinguish these cases, asking people about their goals and preferences is best.
+privacy</a>). But some users might also object, in particular instances or in general.
 
-<span class="practicelab">Sites and user agents should directly ask people about their goals and
-their preferences about use of data about them.</span>
+<span class="practicelab">Sites and user agents should seek to understand and respect people's goals
+and preferences about use of data about them.</span>
 
-Because personal data may be sensitive in unexpected ways, or have risks of future uses that could
-be unexpected or harmful, minimization as a principle applies to personal data that is not currently
+Agents should both be conservative in applying data minimization to any <a
+href="#dfn-ancillary-uses">ancillary use</a> and also not burden the user with additional [=privacy
+labor=]. To that end, user agents may employ user research, solicitation of general preferences, and
+heuristics about sensitivity of data or trust in a particular context. To facilitate site
+understanding of user preferences, user agents can provide browser-configurable signals to directly
+communicate common user preferences.
+
+<aside class="example">
+  Sites and browsers wish to collect telemetry data to determine how frequently features are used or
+  to debug breakages, but the user agent does not want to burden the user with frequent consent
+  requests. A browser could use a first-run dialog to ask the user whether they generally support
+  sharing data to find bugs and improve the Web software they use, and then enable or disable
+  telemetry and reporting APIs based on the user's choice.
+</aside>
+
+<aside class="example">
+  A user visits a mapping website that they regularly visit and clicks a locator icon; although
+  precise geolocation can be very sensitive, the user agent can readily determine the user's intent.
+</aside>
+
+Because personal data may be sensitive in unexpected ways, or have risks of future uses that could be
+unexpected or harmful, minimization as a principle applies to personal data that is not currently
 known to be identifying, sensitive or otherwise potentially harmful.
 
 ## Sensitive Information {#hl-sensitive-information}


### PR DESCRIPTION
This is text just for discussion. It re-writes this section rather than making a small diff, just to make comparison easier; it might need to be revised or merged with existing text or made into separate sections if we want to pursue this approach.

make principles about minimization and about asking users
citations to Data Minimization finding
listing current purposes UAs share outside of particular navigations
senses of when these might be acceptable/willing/supportive
why aggregation is useful for collective purposes, but not complete

This tries to take or address the points from #121 and #165 as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/170.html" title="Last updated on Sep 28, 2022, 10:10 PM UTC (d195761)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/170/1fdfb27...d195761.html" title="Last updated on Sep 28, 2022, 10:10 PM UTC (d195761)">Diff</a>