### PR TITLE
Editorial pass on Personal Data principles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1086,11 +1086,19 @@ site - involves making subjective assumptions about the user.
 <div class="practice">
 
 <span class="practicelab" id="sensitive-vs-non-sensitive-data">
-User agents should treat all personal data as sensitive, and should not
+User agents should treat all [=personal data=] as sensitive, and should not
 attempt to distinguish sensitive from nonsensitive information.
 </span>
 
 </div>
+
+We define <dfn data-lt="data">personal data</dfn> as any information that is
+directly or indirectly related to an identified or identifiable [=person=],
+such as by reference to an [=identifier=] ([[GDPR]], [[OECD-Guidelines]],
+[[Convention-108]]).
+
+If a [=person=] could reasonably be identified or re-identified when [=data=]
+is combined with other [=data=], then that makes that data [=personal data=].
 
 All data and personal information is likely to be sensitive to someone, often
 in ways unanticipated by browser vendors and site operators.
@@ -1588,13 +1596,6 @@ party=] that maintains exclusive access to a person's data can still [=process=]
 but still treat it [=appropriately=].
 
 ## Acting on Data {#acting-on-data}
-
-We define <dfn data-lt="data">personal data</dfn> as any information that is directly or
-indirectly related to an identified or identifiable [=person=], such as by reference to an
-[=identifier=] ([[GDPR]], [[OECD-Guidelines]], [[Convention-108]]).
-
-If a [=person=] could reasonably be identified or re-identified when [=data=] is combined with other
-[=data=], then that makes that data [=personal data=].
 
 <dfn>Privacy</dfn> is achieved in a given [=context=] that either involves [=personal data=] or
 involves information being presented to [=people=] when the [=principles=] of that [=context=] are

--- a/index.html
+++ b/index.html
@@ -1051,10 +1051,6 @@ of an event that occurs nearly-simultaneously on both sites.
 ## Personal Data {#data}
 
 <aside class="issue">
-  This section has not been edited for narrative.
-</aside>
-
-<aside class="issue">
   There is not currently consensus among the authors and contributors to this
   document about the below principles.
   Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this issue</a>
@@ -1063,45 +1059,54 @@ of an event that occurs nearly-simultaneously on both sites.
 
 <div class="practice">
 
-<p><span class="practicelab" id="user-agent-data-sharing">
-User agents should only share and present information about the user that
-the user can reasonably anticipate being shared, and which directly relate to the users overt, immediate goals.
-User agents and sites should be conservative when deciding if information is related to a users goals; the
-longer the chain of reasoning used to justify data collection, the less likely for that data
-collection to be ethical and principled.
-</span></p>
+<span class="practicelab" id="user-agent-data-sharing">
+User agents should only share and present information about someone that the
+person can reasonably anticipate being shared, and which directly relate to
+their overt, immediate goals.
+</span>
 
 </div>
 
-Examples:
+User agents and sites should be conservative when deciding if information is
+related to a person's goals. The longer the chain of reasoning used to justify
+data collection, the less likely for that data collection to be ethical and
+principled.
 
-* Sharing geo-location data with a map website after a user has clicked a "share my location" button has
-  a small number of "hops" between intent and data.
-* Sharing information about the user's selected DNS resolver with a site, so that the site authors can debug
-  possible issues around tail/uncommon resolvers, has a large number of "hops" between user intent (to do
-  a thing on the website) and collection motivation (users like our site, so users will want to share information
-  with us to help us improve the site).
+For example, sharing geo-location data with a map website after a user has
+clicked a "share my location" is appropriate as it is directly related to
+the activity of the person on the website.
+
+On the other hand, sharing information about the user's selected DNS resolver
+with a site, so that the site authors can debug possible issues around
+tail/uncommon resolvers, is far removed from the person's intent to do a thing
+on the website, and the collection motivation - that people like our site, so
+this person will want to share any information with us to help us improve the
+site - involves making subjective assumptions about the user.
 
 <div class="practice">
 
-<p><span class="practicelab" id="sensitive-vs-non-sensitive-data">
-User agents should generally not attempt to distinguish between sensitive and nonsensitive personal data; all
-data and personal information is likely to be sensitive to some users, often in ways unanticipated by
-browser vendors and site operators.
-</span></p>
+<span class="practicelab" id="sensitive-vs-non-sensitive-data">
+User agents should treat all personal data as sensitive, and should not
+attempt to distinguish sensitive from nonsensitive information.
+</span>
 
 </div>
+
+All data and personal information is likely to be sensitive to someone, often
+in ways unanticipated by browser vendors and site operators.
 
 <div class="practice">
 
-<p><span class="practicelab" id="minimal-data-sharing">
-User agents should always aim to share the minimal amount of information with a site
-that is needed for the user to achieve a user's goals. Data collected today can often be used in
-unanticipated ways in the future to enact privacy harms, even data that seems unlikely to
-be identifying, sensitive or otherwise privacy-harming.
-</span></p>
+<span class="practicelab" id="minimal-data-sharing">
+User agents should only share the minimal amount of information with a site
+that is needed to achieve the user's goals.
+</span>
 
 </div>
+
+Data collected today can often be used in unanticipated ways in the future to
+enact privacy harms; even data that seems unlikely to be identifying,
+sensitive or otherwise privacy-harming.
 
 ## Sensitive Information {#hl-sensitive-information}
 


### PR DESCRIPTION
This principle is still under discussion/debate, but I've rearranged it a bit to help with the flow anyway, and trimmed down the text in the principles boxes themselves to their core and used the rest in the supporting prose.

I also moved the definition of 'personal data' from an appendix into this section.

For now I've left the three principles in this section, but I think the first and third could be combined, and the second one perhaps belongs in the Sensitive Information section (which doesn't currently have a Principle). I'll get back to this when I have properly reviewed that section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/178.html" title="Last updated on Aug 23, 2022, 9:03 AM UTC (5dffeff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/178/76b45e0...5dffeff.html" title="Last updated on Aug 23, 2022, 9:03 AM UTC (5dffeff)">Diff</a>