### PR TITLE
Add a principle to support deception (fixes #174)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1546,7 +1546,9 @@ to respond with information that may differ from the truth can be essential in p
 component of fingerprinting mitigation, and can be required for auditing purposes such that an auditor may
 pretend to be someone else in order for instance to detect discrimination.
 
-In some cases, sites do not abide by data minimisation principles and request more information than they realistically require. This principle supports [=people=] in defending under such cases.
+In some cases, sites do not abide by data minimisation principles and request more information than they realistically
+require. This principle supports [=people=] in defending under such cases.
+
 It is worth noting that this principle deliberately empowers [=people=] to provide deceptive information. In the
 general case, the ability for people to present as they wish is more important than the ability of computers to
 prevent them from doing so. Sites should include deception in their threat modelling.

--- a/index.html
+++ b/index.html
@@ -1515,12 +1515,13 @@ trick the [=person=] into opting back into the [=processing=].
 
 <aside class="issue">Some services have the user pay for their use in data. These services aren't necessarily retaliating by denying their services to users who refuse to pay with data, but the details are more complex than we've had time to write.</aside>
 
-## Support Deception {#support-deception}
+## Support Choosing Which Information to Present {#support-choosing-info}
 
 <div class="practice">
-  <span class="practicelab" id="principle-support-deception">
-    [=User agents=] should support [=people=] in providing false or incorrect information to [=parties=]
-    that request it.
+  <span class="practicelab" id="principle-support-choosing-info">
+    [=User agents=] should support [=people=] in choosing which information they provide to [=parties=] that
+    request it, up to and including allowing for the provision of information that may not be factually
+    correct.
   </span>
 </div>
 
@@ -1528,13 +1529,30 @@ trick the [=person=] into opting back into the [=processing=].
 design their products in ways that make it a lot easier for [=people=] to disclose information than not, whereas
 [=people=] typically have to manually wade through options, repeated prompts, and deceptive patterns. In many
 cases, the absence of data — when a [=person=] refuses to provide some information — can also be identifying
-or revealing. [=User agents=] should make it simple for [=people=] to evade such tactics and to live in
-obscurity ([[?Lost-In-Crowd]], [[?Obscurity-By-Design]]) by rendering the provision of incorrect information as easy as
-possible ([[?Obfuscation]]).
+or revealing. Additionally, APIs can be defined or implemented in rigid ways that can prevent people from
+accessing useful functionality (eg. if my geolocation is forcefully set to match my GPS, a restaurant-finding
+site might restrict me to my current location when I want to look for restaurants in a city I will be visiting
+this weekend).
 
-Examples of ways in which a [=user agent=] may support its [=user=]'s obscurity include:
-* Generating domain-specific email addresses so that [=people=] can log into the site without becoming recognisable
-  across contexts.
+[=User agents=] should make it simple for [=people=] to present the identity they wish to and to provide information
+about themselves or their devices in ways that they control. This empowers [=people=] to live in obscurity
+([[?Lost-In-Crowd]], [[?Obscurity-By-Design]]) by rendering the provision of information according to their own
+preferences as easy as possible ([[?Obfuscation]]).
+
+APIs should be designed such that they do not expect to provide the truth about a [=person=] as provided for
+instance by a sensor or recorded data. Instead, the API could indicate a [=person=]'s preference, a [=person=]'s
+chosen identity, a [=person=]'s query or interest, or a [=person=]'s selected communication style. Directing APIs
+to respond with information that may differ from the truth can be essential in protecting [=people=], is a key
+component of fingerprinting mitigation, and can be required for auditing purposes such that an auditor may
+pretend to be someone else in order for instance to detect discrimination.
+
+It is worth noting that this principle deliberately empowers [=people=] to provide deceptive information. In the
+general case, the ability for people to present as they wish is more important than the ability of computers to
+prevent them from doing so. Sites should include deception in their threat modelling.
+
+Examples of ways in which a [=user agent=] may support this principle include:
+* Generating domain-specific email addresses or other directed identifiers so that [=people=] can log into the
+  site without becoming recognisable across contexts.
 * Offering the option to produce fake geolocation and accelerometry data, with parameters specified by the [=user=].
 * Making it easy to upload a picture while pretending to have it taken by the camera.
 * Faking the acceptance of notification prompts (or pretending that notifications have already been accepted).

--- a/index.html
+++ b/index.html
@@ -1556,10 +1556,10 @@ prevent them from doing so. Sites should include deception in their threat model
 Examples of ways in which a [=user agent=] may support this principle include:
 * Generating domain-specific email addresses or other directed identifiers so that [=people=] can log into the
   site without becoming recognisable across contexts.
-* Offering the option to produce fake geolocation and accelerometry data, with parameters specified by the [=user=].
+* Offering the option to generate geolocation and accelerometry data with parameters specified by the [=user=].
 * Making it easy to upload a picture while pretending to have it taken by the camera.
 * Faking the acceptance of notification prompts (or pretending that notifications have already been accepted).
-* Filtering outbound network traffic so as to replace specific strings (TCF, hashed email, navigation identifiers).
+* Filtering outbound network traffic so as to replace specific strings (hashed email, navigation identifiers, consent strings).
 * Randomly swapping third-party cookies with the browsers of other [=people=].
 
 <!--

--- a/index.html
+++ b/index.html
@@ -196,6 +196,12 @@
           href: 'https://www.cambridge.org/core/books/industry-unbound/787989F90DBFC08E47546178A7AB04F7',
           publisher: 'Cambridge University Press',
         },
+        'Lost-In-Crowd': {
+          title: 'Why You Can No Longer Get Lost in the Crowd',
+          authors: ['Woodrow Hartzog', 'Evan Selinger'],
+          href: 'https://www.nytimes.com/2019/04/17/opinion/data-privacy.html',
+          publisher: 'The New York Times',
+        },
         'NIST-800-63A': {
           title: 'Digital Identity Guidelines: Enrollment and Identity Proofing Requirements',
           href: 'https://pages.nist.gov/800-63-3/sp800-63a.html',
@@ -208,6 +214,17 @@
           author: ['Robin Berjon'],
           href: 'https://open.nytimes.com/how-the-new-york-times-thinks-about-your-privacy-bc07d2171531',
           publisher: 'NYT Open',
+        },
+        'Obfuscation': {
+          title: 'Obfuscation: A User\'s Guide for Privacy and Protest',
+          authors: ['Finn Brunton', 'Helen Nissenbaum'],
+          href: 'https://www.penguinrandomhouse.com/books/657301/obfuscation-by-finn-brunton-and-helen-nissenbaum/',
+          publisher: 'Penguin Random House',
+        },
+        'Obscurity-By-Design': {
+          title: 'Obscurity by Design',
+          authors: ['Woodrow Hartzog', 'Frederic Stutzman'],
+          href: 'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2284583',
         },
         'OECD-Guidelines': {
           title: 'OECD Guidelines on the Protection of Privacy and Transborder Flows of Personal Data',
@@ -939,7 +956,7 @@ If a [=site=] includes multiple [=contexts=] whose [=principles=] indicate that 
 share data between the contexts, the fact that those distinct [=contexts=] fall inside a single
 [=machine-enforceable context=] doesn't make sharing data or [=cross-context
 recognition|recognizing=] [=identities=] any less [=inappropriate=].
- 
+
 The user agent and identity related web features should:
 * help users present the identity that they want to present to a given website.
   * should not reveal user's profile information without user consent.
@@ -1497,6 +1514,32 @@ unrelated feature, by decreasing the quality of the service, or by trying to caj
 trick the [=person=] into opting back into the [=processing=].
 
 <aside class="issue">Some services have the user pay for their use in data. These services aren't necessarily retaliating by denying their services to users who refuse to pay with data, but the details are more complex than we've had time to write.</aside>
+
+## Support Deception {#support-deception}
+
+<div class="practice">
+  <span class="practicelab" id="principle-support-deception">
+    [=User agents=] should support [=people=] in providing false or incorrect information to [=parties=]
+    that request it.
+  </span>
+</div>
+
+[=Parties=] can invest time and energy into automating ways of gathering [=data=] from [=people=] and can
+design their products in ways that make it a lot easier for [=people=] to disclose information than not, whereas
+[=people=] typically have to manually wade through options, repeated prompts, and deceptive patterns. In many
+cases, the absence of data — when a [=person=] refuses to provide some information — can also be identifying
+or revealing. [=User agents=] should make it simple for [=people=] to evade such tactics and to live in
+obscurity ([[?Lost-In-Crowd]], [[?Obscurity-By-Design]]) by rendering the provision of incorrect information as easy as
+possible ([[?Obfuscation]]).
+
+Examples of ways in which a [=user agent=] may support its [=user=]'s obscurity include:
+* Generating domain-specific email addresses so that [=people=] can log into the site without becoming recognisable
+  across contexts.
+* Offering the option to produce fake geolocation and accelerometry data, with parameters specified by the [=user=].
+* Making it easy to upload a picture while pretending to have it taken by the camera.
+* Faking the acceptance of notification prompts (or pretending that notifications have already been accepted).
+* Filtering outbound network traffic so as to replace specific strings (TCF, hashed email, navigation identifiers).
+* Randomly swapping third-party cookies with the browsers of other [=people=].
 
 <!--
 # EVERYTHING BELOW THIS LINE IS MATERIAL

--- a/index.html
+++ b/index.html
@@ -1546,6 +1546,7 @@ to respond with information that may differ from the truth can be essential in p
 component of fingerprinting mitigation, and can be required for auditing purposes such that an auditor may
 pretend to be someone else in order for instance to detect discrimination.
 
+In some cases, sites do not abide by data minimisation principles and request more information than they realistically require. This principle supports [=people=] in defending under such cases.
 It is worth noting that this principle deliberately empowers [=people=] to provide deceptive information. In the
 general case, the ability for people to present as they wish is more important than the ability of computers to
 prevent them from doing so. Sites should include deception in their threat modelling.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#support-deception
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/181.html#support-deception" title="Last updated on Oct 26, 2022, 4:20 PM UTC (b237e23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/181/76b45e0...b237e23.html" title="Last updated on Oct 26, 2022, 4:20 PM UTC (b237e23)">Diff</a>