### PR TITLE
Ancillary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1053,6 +1053,26 @@ can also be done by having someone navigate to a link that has been decorated wi
 collecting the same piece of identifying information on both sites, or by correlating the timestamps
 of an event that occurs nearly-simultaneously on both sites.
 
+## Data minimization {#data}
+
+<span class="practicelab">Sites, user agents and other parties should minimize the amount of data
+about people that is shared with or transferred between parties on the Web.</span>
+
+Data minimization limits the risks of data being disclosed or misused and also makes it possible to
+more meaningfully provide people with understandable decisions about data about them.
+
+<span class="practicelab">Web APIs should be designed to minimize the amount of data that is requested
+and provide granularity and user controls over personal data that is communicated to sites.</span>
+
+<aside class="note">
+This principle was further explored in an earlier TAG draft on <a
+href="https://www.w3.org/2001/tag/doc/APIMinimization-20100605.html">Data Minimization in Web
+APIs</a>.
+</aside>
+
+Because personal data may be sensitive in unexpected ways, or have risks of future uses that could be
+unexpected or harmful, minimization as a principle applies to personal data that is not currently
+known to be identifying, sensitive or otherwise potentially harmful.
 
 ## Personal Data {#data}
 

--- a/index.html
+++ b/index.html
@@ -1110,6 +1110,9 @@ page for <dfn>ancillary uses</dfn> including:
 * performance, including caching and prefetching content; 
 * software updates.
 
+<dfn>Telemetry and analytics</dfn>, including browser telemetry and site telemetry, are a common
+cluster of ancillary uses.
+
 In some cases, mechanisms for sharing data are provided in order to minimize some other data
 collection mechanism identified as more intrusive or costly.
 
@@ -1152,8 +1155,11 @@ heuristics about sensitivity of data or trust in a particular context. To facili
 understanding of user preferences, user agents can provide browser-configurable signals to directly
 communicate common user preferences.
 
-Revealing user preferences or other heuristics in providing or disabling functionality could also be
-used as part of <a>browser fingerprinting</a> to identify users across sites.
+<div class="practice">
+  <span class="practicelab">Specifications that define functionality for telemetry and analytics
+  should explicitly note the <a href="#dfn-telemetry-and-analytics">analytics</a> use to facilitate modal or general user
+  choices.</span>
+</div>
 
 <aside class="example">
   Sites and browsers wish to collect telemetry data to determine how frequently features are used or
@@ -1167,6 +1173,12 @@ used as part of <a>browser fingerprinting</a> to identify users across sites.
   A user visits a mapping website that they regularly visit and clicks a locator icon; although
   precise geolocation can be very sensitive, the user agent can readily determine the user's intent.
 </aside>
+
+Data exposed for ancillary uses including <a href="#dfn-telemetry-and-analytics">telemetry</a> may
+often reveal characteristics of user configuration, device, environment or behavior that could be
+used as part of <a>browser fingerprinting</a> to identify users across sites. Revealing user
+preferences or other heuristics in providing or disabling functionality could also contribute to a
+browser fingerprint.
 
 ## Sensitive Information {#hl-sensitive-information}
 

--- a/index.html
+++ b/index.html
@@ -1087,10 +1087,8 @@ known to be identifying, sensitive or otherwise potentially harmful.
 ### Ancillary uses
 
 <aside class="issue">
-  There is not currently consensus among the authors and contributors to this document about the below
-  principles. Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this
-  issue</a>
-  for more details.
+  See <a href="https://github.com/w3ctag/privacy-principles/issues/150">the issue on ancillary
+  uses</a> for ongoing discussion and iteration on this principle.
 </aside>
 
 In maintaining duties of <a href="#dfn-duty-of-protection">protection</a>, <a

--- a/index.html
+++ b/index.html
@@ -1074,60 +1074,94 @@ Because personal data may be sensitive in unexpected ways, or have risks of futu
 unexpected or harmful, minimization as a principle applies to personal data that is not currently
 known to be identifying, sensitive or otherwise potentially harmful.
 
-## Personal Data {#data}
+### Ancillary uses
 
 <aside class="issue">
-  This section has not been edited for narrative.
-</aside>
-
-<aside class="issue">
-  There is not currently consensus among the authors and contributors to this
-  document about the below principles.
-  Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this issue</a>
+  There is not currently consensus among the authors and contributors to this document about the below
+  principles. Please see <a href="https://github.com/w3ctag/privacy-principles/issues/150">this
+  issue</a>
   for more details.
 </aside>
 
+In maintaining duties of <a href="#dfn-duty-of-protection">protection</a>, <a
+href="#dfn-duty-of-discretion">discretion</a> and <a href="#dfn-duty-of-loyalty">loyalty</a>, user
+agents should be conservative when sharing data not necessary to satisfy a user's immediate goals.
+
+On the Web, user agents and sites often communicate data even outside the need to load and display a
+page for <dfn>ancillary uses</dfn> including: 
+
+* browser telemetry, including: 
+  * performance measurements, 
+  * measuring feature usage, 
+  * debugging site, browser and networking issues, and, 
+  * detecting security problems or attacks; 
+* site telemetry, including: 
+  * performance measurements, 
+  * analytics about usage and visitors, 
+  * debugging site issues, and, 
+  * detecting security problems or attacks; 
+* advertising and social media sharing, including: 
+  * measurement, targeting, ad auctions, personalization, fraud prevention; 
+* performance, including caching and prefetching content; 
+* software updates.
+
+In some cases, mechanisms for sharing data are provided in order to minimize some other data
+collection mechanism identified as more intrusive or costly.
+
+Different users will want to share different kinds and amounts of data with websites. For some uses,
+some people would reasonably anticipate sharing such data or identify that use as a
+commonly-accepted contextual norm and some people would be willing to participate (for example,
+might have explicitly decided to contribute if they had the time and understanding to consider
+details about such a use) and some people would identify those uses as supporting their own goals. 
+
+Aggregated or <a href="#dfn-de-identified">de-identified</a> data is often more likely to be
+acceptable in these senses and often still contributes to the collective benefit while minimizing
+privacy threats to a particular individual (see <a href="#principle-collective-privacy">collective
+privacy</a>). But some people might also object, in particular instances or in general.
+
+<aside class="example">
+  Privacy-preserving measurement techniques may be used for aggregate calculations while minimizing
+  the parties that have access to personal data about many individual people. Encryption and
+  privacy-preserving proxies may be used to minimize the parties that have access to personal data or
+  to hide the contents of personal data used for telemetry or other kinds of measurement. But even
+  with those protections, some people may prefer not to participate in some kinds of measurement.
+
+  Ongoing work on privacy-preserving technologies in the <abbr title="Internet Engineering Task
+  Force">IETF</abbr> <a href="https://datatracker.ietf.org/wg/ppm/about/"><abbr
+  title="privacy-preserving measurement">ppm</abbr></a>, <abbr title="Internet Research Task
+  Force">IRTF</abbr> <a href="https://datatracker.ietf.org/rg/pearg/about/"><abbr title="Privacy
+  Enhancements and Assessments Research Group">pearg</abbr></a> and W3C <a
+  href="https://patcg.github.io/"><abbr title="Private Advertising Technology Community
+  Group">PATCG</abbr></a> groups may be relevant. 
+</aside>
+
 <div class="practice">
-
-<p><span class="practicelab" id="user-agent-data-sharing">
-User agents should only share and present information about the user that
-the user can reasonably anticipate being shared, and which directly relate to the users overt, immediate goals.
-User agents and sites should be conservative when deciding if information is related to a users goals; the
-longer the chain of reasoning used to justify data collection, the less likely for that data
-collection to be ethical and principled.
-</span></p>
-
+  <span class="practicelab">Sites and user agents should seek to understand and respect people's
+  goals and preferences about use of data about them.</span>
 </div>
 
-Examples:
+Agents should both be careful, cautious and conservative in applying data minimization to any <a
+href="#dfn-ancillary-uses">ancillary use</a> and also not burden the user with additional [=privacy
+labor=]. To that end, user agents may employ user research, solicitation of general preferences, and
+heuristics about sensitivity of data or trust in a particular context. To facilitate site
+understanding of user preferences, user agents can provide browser-configurable signals to directly
+communicate common user preferences.
 
-* Sharing geo-location data with a map website after a user has clicked a "share my location" button has
-  a small number of "hops" between intent and data.
-* Sharing information about the user's selected DNS resolver with a site, so that the site authors can debug
-  possible issues around tail/uncommon resolvers, has a large number of "hops" between user intent (to do
-  a thing on the website) and collection motivation (users like our site, so users will want to share information
-  with us to help us improve the site).
+Revealing user preferences or other heuristics in providing or disabling functionality could also be
+used as part of <a>browser fingerprinting</a> to identify users across sites.
 
-<div class="practice">
+<aside class="example">
+  Sites and browsers wish to collect telemetry data to determine how frequently features are used or
+  to debug breakages, but the user agent does not want to burden the user with frequent consent
+  requests. A browser could use a first-run dialog to ask the user whether they generally support
+  sharing data to find bugs and improve the Web software they use, and then enable or disable
+  telemetry and reporting APIs based on the user's choice.
+</aside>
 
-<p><span class="practicelab" id="sensitive-vs-non-sensitive-data">
-User agents should generally not attempt to distinguish between sensitive and nonsensitive personal data; all
-data and personal information is likely to be sensitive to some users, often in ways unanticipated by
-browser vendors and site operators.
-</span></p>
-
-</div>
-
-<div class="practice">
-
-<p><span class="practicelab" id="minimal-data-sharing">
-User agents should always aim to share the minimal amount of information with a site
-that is needed for the user to achieve a user's goals. Data collected today can often be used in
-unanticipated ways in the future to enact privacy harms, even data that seems unlikely to
-be identifying, sensitive or otherwise privacy-harming.
-</span></p>
-
-</div>
+<aside class="example">
+  A user visits a mapping website that they regularly visit and clicks a locator icon; although
+  precise geolocation can be very sensitive, the user agent can readily determine the user's intent.
+</aside>
 
 ## Sensitive Information {#hl-sensitive-information}
 

--- a/meetings/2022-09-07-minutes.md
+++ b/meetings/2022-09-07-minutes.md
@@ -1,6 +1,7 @@
 # TAG Privacy TF - Wed, 7 September 2022
 
-present: Don, Jeffrey, Robin, Peter, Dan, Nick. 
+present: Don, Jeffrey, Robin, Peter, Dan, Nick
+
 regrets: christine, amy, wendy, shubhie, tess
 
 


### PR DESCRIPTION
separate pr (building on minimization) with subsection for ancillary uses


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#ancillary-uses
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/184.html#ancillary-uses" title="Last updated on Sep 28, 2022, 9:59 PM UTC (34a5503)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/184/8eb03bf...34a5503.html" title="Last updated on Sep 28, 2022, 9:59 PM UTC (34a5503)">Diff</a>