### PR TITLE
introducing the different parties in information flows and the different threats

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,21 @@ unexpected shocking images, loud noises while one intends to sleep, manipulative
 interruptive messages when a person's focus is on something else, or harassment when they seek
 social interactions.
 
+On the Web, [=information flows=] may involve a wide variety of [=parties=] that are not always
+recognizable or obvious to a user within a particular interaction. Visiting a website may involve
+the parties that operate that site and its functionality, but also network attackers, which may
+include: Internet service providers; other network operators; local institutions providing a network
+connection including schools, libraries or universities; government intelligence services; malicious
+hackers who have gained access to the network or the systems of any of the other parties. High-level
+threats including [=surveillance=] may be pursued by these parties. Pervasive monitoring, a form of
+large-scale, indiscriminate surveillance, is a known attack on the privacy of users of the Internet
+and the Web [[RFC7258]].
+
+Information flows may also involve other people &mdash; for example, other users of a site &mdash;
+which could include friends, family members, teachers, strangers or government officials. Some
+threats to privacy, including both [=disclosure=] and harassment, may be particular to the other
+people involved in the information flow.
+
 ## Individual Autonomy {#autonomy}
 
 A [=person=]'s <dfn data-lt="autonomous">autonomy</dfn> is their ability to make decisions of their own volition,

--- a/index.html
+++ b/index.html
@@ -481,13 +481,13 @@ social interactions.
 
 On the Web, [=information flows=] may involve a wide variety of [=parties=] that are not always
 recognizable or obvious to a user within a particular interaction. Visiting a website may involve
-the parties that operate that site and its functionality, but also network attackers, which may
-include: Internet service providers; other network operators; local institutions providing a network
-connection including schools, libraries or universities; government intelligence services; malicious
-hackers who have gained access to the network or the systems of any of the other parties. High-level
-threats including [=surveillance=] may be pursued by these parties. Pervasive monitoring, a form of
-large-scale, indiscriminate surveillance, is a known attack on the privacy of users of the Internet
-and the Web [[RFC7258]].
+the parties that operate that site and its functionality, but also parties with network access,
+which may include: Internet service providers; other network operators; local institutions providing
+a network connection including schools, libraries or universities; government intelligence services;
+malicious hackers who have gained access to the network or the systems of any of the other parties.
+High-level threats including [=surveillance=] may be pursued by these parties. Pervasive monitoring,
+a form of large-scale, indiscriminate surveillance, is a known attack on the privacy of users of the
+Internet and the Web [[RFC7258]].
 
 Information flows may also involve other people &mdash; for example, other users of a site &mdash;
 which could include friends, family members, teachers, strangers or government officials. Some

--- a/index.html
+++ b/index.html
@@ -490,7 +490,7 @@ a form of large-scale, indiscriminate surveillance, is a known attack on the pri
 Internet and the Web [[RFC7258]].
 
 Information flows may also involve other people &mdash; for example, other users of a site &mdash;
-which could include friends, family members, teachers, strangers or government officials. Some
+which could include friends, family members, teachers, strangers, or government officials. Some
 threats to privacy, including both [=disclosure=] and harassment, may be particular to the other
 people involved in the information flow.
 


### PR DESCRIPTION
Adding this to the introduction where information flows and actors/parties are first addressed, but could be included elsewhere, perhaps in a step-by-step process for identifying information flows and privacy threats.

starts to address #161


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#dfn-information
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/185.html#dfn-information" title="Last updated on Oct 25, 2022, 9:07 PM UTC (2438767)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/185/a978fa0...2438767.html" title="Last updated on Oct 25, 2022, 9:07 PM UTC (2438767)">Diff</a>