### PR TITLE
Avoid asking for fake consent

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,6 +549,14 @@ there should be a vivid indicator that data is being transmitted shown at all ti
 that the person can easily switch it off. In general, providing [=consent=] should be rare,
 difficult, highly intentional, and temporary.
 
+In some situations, a [=party=] can comply with a requirement to get a [=person=] to perform
+some action that is treated as <q>consent</q> without obtaining the person's actual, informed [=consent=].
+Because requests for consent should be important enough to justify attention from a [=person=], a
+[=party=] should avoid distracting the user with attempts to get fake <q>consent</q> in situations
+when actual [=consent=] would not be required by these principles.  Responding to unnecessary requests
+for consent, real or fake, is unacceptable [=privacy labour=] and limits how much time and attention
+a [=person=] can devote to meaningful [=consent=] decisions.
+
 When an [=opt-out=] mechanism exists, it should preferably be complemented by a
 <dfn>global opt-out</dfn> mechanism. The function of a [=global opt-out=] mechanism is to
 rectify the <dfn class="export">automation asymmetry</dfn> whereby service providers can automate
@@ -1480,6 +1488,9 @@ more accountable. Examples of mitigations include:
 Attempts to obtain consent to [=processing=] that is not in accordance with the person's
 true preferences result in imposing unwanted [=privacy labour=] on the person, and may
 result in people erroneously giving consent that they regret later.
+
+Attempts to obtain consent that is not needed for the processing to be performed are
+also harmful because they tend to distract the user from meaningful requests for consent.
 
 <div class="practice">
 <p>


### PR DESCRIPTION
Fake consent is worse than no consent, because of privacy labour and distraction from consent requests that should get careful attention.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#opt-in-out, #consent-principles
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/190.html" title="Last updated on Nov 2, 2022, 12:06 AM UTC (0c5256e)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/190.html#opt-in-out" title="#opt-in-out">#opt-in-out</a>) (<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/190.html#consent-principles" title="#consent-principles">#consent-principles</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/190/6fffbb6...0c5256e.html" title="Last updated on Nov 2, 2022, 12:06 AM UTC (0c5256e)">Diff</a>