### PR TITLE
Explain how to balance device owner vs user rights.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1525,7 +1525,7 @@ also says what sort of user is expected to agree. Users in other classes can the
 appropriately.
 
 <aside class="issue">
-Link this to the "guardians" section when that's written.
+Link this to [[[#guardians]]].
 </aside>
 
 ## Harassment
@@ -1713,8 +1713,7 @@ agent=] needs to warn the child about how it's configured so that the child can 
 
 <aside class="issue">
 
-Add crosslinks to the <a href="https://github.com/w3ctag/privacy-principles/pull/202">upcoming
-device owners section</a>.
+Add crosslinks to [[[#device-administrators]]].
 
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -1473,52 +1473,55 @@ to offer better protection by default? Given the contested nature of the [^a/pin
 the absence of a forcing function to support collective enforcement, the scheme failed to deliver
 improved privacy.
 
-## Device Owners {#device-owners}
+## Device Owners and Administrators {#device-administrators}
 
 <div class="practice">
 <span class="practicelab" id="principle-owned-devices-disclose-surveillance">
-[=User agents=] must not help a [=device owner=] spy on the people using their devices without those
-people's knowledge.
+[=User agents=] must not help a device [=administrator=] surveil the people using the devices they
+administrate without those people's knowledge.
 </span>
 </div>
 
 <div class="practice">
 <span class="practicelab" id="principle-reasonable-disclosure-on-owned-devices">
-[=User agents=] should only tell a [=device owner=] about user behavior when that disclosure is
-necessary to enforce reasonable constraints on use of the device.
+[=User agents=] should only tell a device [=administrator=] about user behavior when that disclosure
+is necessary to enforce reasonable constraints on use of the device.
 </span>
 </div>
 
 
-Many [=user agents=] run on devices that are owned by a different [=actor=] than the [=person=]
-using the [=user agent=]. There are several different sorts of these <dfn>device owners</dfn>, which
-include:
+Computing devices have <dfn data-lt="device owner">owners</dfn>, and those owners have
+<dfn>administrator</dfn> access to the devices in order to install and configure the programs,
+including [=user agents=], that run on them. Sometimes, as in the cases of an employer providing a
+device to an employee, a friend loaning a device to their visitor, or a parent providing a device to
+their small child, the [=person=] using a device doesn't own the device or have [=administrator=]
+access to it. Other times, as in the cases of intimate partners or one relative helping another
+relative with their device, the owner and primary user of a device might not be the only person with
+[=administrator=] access. As a program running on a device, a [=user agent=] generally can't tell
+whether the [=administrator=] who has installed and configured it was authorized by the device's
+actual owner.
 
-<table class="data">
-<thead>
-<tr><th>[=device owner|Owner=]<th>User
-<tbody>
-<tr><td>Employer<td>Employee
-<tr><td>Parent<td>Child
-<tr><td>Romantic partner<td>Romantic partner
-<tr><td>Friend<td>Visitor
-</table>
+These relationships can involve power imbalances. A child may have difficulty accessing any
+computing devices other than the ones their parent provides. A victim of abuse might not be able to
+prevent their partner from having [=administrator=] access to their devices. An employee might have
+to agree to use their employer's devices in order to keep their job.
 
 While a [=device owner=] has an interest and sometimes a responsibility to make sure their device is
-used in the ways they intended, the person _using_ the device still has a right to privacy while
+used in the ways they intended, the [=person=] _using_ the device still has a right to privacy while
 using it. The above principles enforce this right to privacy in two ways:
 
-1. [=User agent=] developers need to consider whether requests from [=device owners=] are
-   reasonable, and refuse to implement unreasonable requests, even if that means fewer sales. Owner
-   needs must not simply trump user needs in the <a
+1. [=User agent=] developers need to consider whether requests from [=device owners=] and
+   [=administrators=] are reasonable, and refuse to implement unreasonable requests, even if that
+   means fewer sales. Owner/administrator needs must not simply trump user needs in the <a
    data-cite="design-principles#priority-of-constituencies">priority of constituencies</a>.
 1. Even when information disclosure is reasonable, the [=person=] whose data is being disclosed
-   needs to opt into that disclosure by using the device after being told what's going to happen.
+   needs to know about it so that they can avoid doing things that would lead to unwanted
+   consequences.
 
-Some [=device owner=] requests might be reasonable for some sorts of users, like employees or
-especially children, but not be reasonable for other sorts, like friends or romantic partners. In
-those cases, the [=user agent=] can explain what the [=device owner=] is going to learn in a way
-that also says what sort of user is expected to agree. Users in other classes can then react
+Some [=administrator=] requests might be reasonable for some sorts of users, like employees or
+especially children, but not be reasonable for other sorts, like friends or intimate partners. In
+those cases, the [=user agent=] can explain what the administrator is going to learn in a way that
+also says what sort of user is expected to agree. Users in other classes can then react
 appropriately.
 
 <aside class="issue">

--- a/index.html
+++ b/index.html
@@ -1473,9 +1473,56 @@ to offer better protection by default? Given the contested nature of the [^a/pin
 the absence of a forcing function to support collective enforcement, the scheme failed to deliver
 improved privacy.
 
-## Guardians and Device Owners {#guardians-and-owners}
+## Device Owners {#device-owners}
 
-<aside class="issue" data-number="2">
+<div class="practice">
+<span class="practicelab" id="principle-owned-devices-disclose-surveillance">
+[=User agents=] must not help a [=device owner=] spy on the people using their devices without those
+people's knowledge.
+</span>
+</div>
+
+<div class="practice">
+<span class="practicelab" id="principle-reasonable-disclosure-on-owned-devices">
+[=User agents=] should only tell a [=device owner=] about user behavior when that disclosure is
+necessary to enforce reasonable constraints on use of the device.
+</span>
+</div>
+
+
+Many [=user agents=] run on devices that are owned by a different [=actor=] than the [=person=]
+using the [=user agent=]. There are several different sorts of these <dfn>device owners</dfn>, which
+include:
+
+<table class="data">
+<thead>
+<tr><th>[=device owner|Owner=]<th>User
+<tbody>
+<tr><td>Employer<td>Employee
+<tr><td>Parent<td>Child
+<tr><td>Romantic partner<td>Romantic partner
+<tr><td>Friend<td>Visitor
+</table>
+
+While a [=device owner=] has an interest and sometimes a responsibility to make sure their device is
+used in the ways they intended, the person _using_ the device still has a right to privacy while
+using it. The above principles enforce this right to privacy in two ways:
+
+1. [=User agent=] developers need to consider whether requests from [=device owners=] are
+   reasonable, and refuse to implement unreasonable requests, even if that means fewer sales. Owner
+   needs must not simply trump user needs in the <a
+   data-cite="design-principles#priority-of-constituencies">priority of constituencies</a>.
+1. Even when information disclosure is reasonable, the [=person=] whose data is being disclosed
+   needs to opt into that disclosure by using the device after being told what's going to happen.
+
+Some [=device owner=] requests might be reasonable for some sorts of users, like employees or
+especially children, but not be reasonable for other sorts, like friends or romantic partners. In
+those cases, the [=user agent=] can explain what the [=device owner=] is going to learn in a way
+that also says what sort of user is expected to agree. Users in other classes can then react
+appropriately.
+
+<aside class="issue">
+Link this to the "guardians" section when that's written.
 </aside>
 
 ## Harassment


### PR DESCRIPTION
While writing this, I concluded that the "guardians" section belongs inside the vulnerable-people section, so I kept this focused on device owners.

Fixes #2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#device-administrators
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/202.html#device-administrators" title="Last updated on Dec 14, 2022, 5:11 PM UTC (8046e06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/202/fca8866...jyasskin:8046e06.html" title="Last updated on Dec 14, 2022, 5:11 PM UTC (8046e06)">Diff</a>