### PR TITLE
Add a section on guardians

### DIFF
--- a/index.html
+++ b/index.html
@@ -1653,6 +1653,18 @@ access to the help they need.
 
 </aside>
 
+<aside class="example" id="example-it-as-guardians" title="IT departments as guardians">
+
+An employee of a large company can be a tempting target for malware, but most employees don't have
+the time or expertise to be aware of all of the latest threats. Their IT department can invest in
+scalable defences, which they then apply by configuring the [=user agents=] they manage.
+
+However, employees still need to be able to organize into unions and blow the whistle on illegal
+activity by their employers, without getting caught by undesired aspects of their IT departments'
+surveillance.
+
+</aside>
+
 <aside class="issue">
 
 Add crosslinks to the <a href="https://github.com/w3ctag/privacy-principles/pull/202">upcoming

--- a/index.html
+++ b/index.html
@@ -1655,9 +1655,9 @@ child is old enough to make their own decisions about it.
 
 A child may discover that they're LGBT and need to find supportive resources online. If they have a
 homophobic or transphobic parent, that parent might have configured their [=user agent=] to either
-block or inform the parent when the child visits pro-LGBT websites. The [=user agent=] needs to warn
-the child about how it's configured so that the child can know to ask a better [=guardian=] for
-access to the help they need.
+block or inform the parent when the child visits web pages about LGBT-related subjects. The [=user
+agent=] needs to warn the child about how it's configured so that the child can know to ask a better
+[=guardian=] for access to the help they need.
 
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -1616,6 +1616,32 @@ installed software or connected devices).
 </p>
 </div>
 
+### Guardians {#guardians}
+
+Some classes of vulnerable people tend to be unable to make good decisions about their own web use,
+and need a <dfn>guardian</dfn> to help them. Children are a widely recognized example of this class,
+with their parents commonly acting as their [=guardians=].  A person with a [=guardian=] is known as
+a <dfn>ward</dfn>. In some limited ways, employees with valuable access to systems can be seen as
+[=wards=] of their IT departments.
+
+Many legal systems treat these guardianship relationships as a set of rights that the [=guardian=]
+possesses. We prefer to instead think of the [=ward=] having a right to make informed decisions and
+exercise their autonomy. Their [=guardian=] then has an _obligation_ to help their [=ward=] do so
+when the [=ward=]'s abilities aren't sufficient, even if that conflicts with the [=guardian=]'s
+desires. In practice, many [=wards=] discover that their [=guardian=] is not making decisions in the
+[=ward=]'s best interest, and it's critical that such [=wards=] have a way to escape their
+misbehaving guardian.
+
+Historically, the Web has provided exactly this escape route, and [=user agents=] should preserve
+that feature by correctly balancing a benevolent [=guardian=]'s need to protect their [=ward=] from
+dangers against other [=wards=]' need to protect themselves from their dangerous [=guardians=].
+
+<aside class="issue">
+
+Add crosslinks to the <a href="https://github.com/w3ctag/privacy-principles/pull/202">upcoming
+device owners section</a>.
+
+</aside>
 
 ## Consent, Withdrawal of Consent, Opt-Outs, and Objections {#consent-principles}
 

--- a/index.html
+++ b/index.html
@@ -1618,11 +1618,19 @@ installed software or connected devices).
 
 ### Guardians {#guardians}
 
+<div class="practice">
+<span class="practicelab" id="principle-guardians-have-responsibilities">
+A [=user agent=] may only provide information about a [=ward=] to a [=guardian=] for the purpose of
+helping that [=guardian=] uphold their responsibilities to their [=ward=]. This system must include
+measures to help [=wards=] who realize that their [=guardian=] isn't acting in the [=ward=]'s
+interest.</span>
+</div>
+
+
 Some classes of vulnerable people tend to be unable to make good decisions about their own web use,
 and need a <dfn>guardian</dfn> to help them. Children are a widely recognized example of this class,
-with their parents commonly acting as their [=guardians=].  A person with a [=guardian=] is known as
-a <dfn>ward</dfn>. In some limited ways, employees with valuable access to systems can be seen as
-[=wards=] of their IT departments.
+with their parents often acting as their [=guardians=]. A person with a [=guardian=] is known as
+a <dfn>ward</dfn>.
 
 Many legal systems treat these guardianship relationships as a set of rights that the [=guardian=]
 possesses. We prefer to instead think of the [=ward=] having a right to make informed decisions and
@@ -1634,7 +1642,7 @@ misbehaving guardian.
 
 Historically, the Web has provided exactly this escape route, and [=user agents=] should preserve
 that feature by correctly balancing a benevolent [=guardian=]'s need to protect their [=ward=] from
-dangers against other [=wards=]' need to protect themselves from their dangerous [=guardians=].
+dangers against other [=wards=]' need to protect themselves from their misbehaving [=guardians=].
 
 <aside class="example" id="example-protective-parent" title="Protective parents">
 
@@ -1650,18 +1658,6 @@ homophobic or transphobic parent, that parent might have configured their [=user
 block or inform the parent when the child visits pro-LGBT websites. The [=user agent=] needs to warn
 the child about how it's configured so that the child can know to ask a better [=guardian=] for
 access to the help they need.
-
-</aside>
-
-<aside class="example" id="example-it-as-guardians" title="IT departments as guardians">
-
-An employee of a large company can be a tempting target for malware, but most employees don't have
-the time or expertise to be aware of all of the latest threats. Their IT department can invest in
-scalable defences, which they then apply by configuring the [=user agents=] they manage.
-
-However, employees still need to be able to organize into unions and blow the whistle on illegal
-activity by their employers, without getting caught by undesired aspects of their IT departments'
-surveillance.
 
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -1636,6 +1636,23 @@ Historically, the Web has provided exactly this escape route, and [=user agents=
 that feature by correctly balancing a benevolent [=guardian=]'s need to protect their [=ward=] from
 dangers against other [=wards=]' need to protect themselves from their dangerous [=guardians=].
 
+<aside class="example" id="example-protective-parent" title="Protective parents">
+
+A parent might configure a small child's [=user agent=] to block access to violent content until the
+child is old enough to make their own decisions about it.
+
+</aside>
+
+<aside class="example" id="example-lgbt-kid" title="An LGBT child">
+
+A child may discover that they're LGBT and need to find supportive resources online. If they have a
+homophobic or transphobic parent, that parent might have configured their [=user agent=] to either
+block or inform the parent when the child visits pro-LGBT websites. The [=user agent=] needs to warn
+the child about how it's configured so that the child can know to ask a better [=guardian=] for
+access to the help they need.
+
+</aside>
+
 <aside class="issue">
 
 Add crosslinks to the <a href="https://github.com/w3ctag/privacy-principles/pull/202">upcoming


### PR DESCRIPTION
Intended to fix #157.

@IreneKnapp, how does this look?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#guardians
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/203.html#guardians" title="Last updated on Dec 14, 2022, 5:08 PM UTC (e77bd36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/203/94428dc...jyasskin:e77bd36.html" title="Last updated on Dec 14, 2022, 5:08 PM UTC (e77bd36)">Diff</a>