### PR TITLE
Refine the definition of "context" to avoid re-using "purpose".

### DIFF
--- a/index.html
+++ b/index.html
@@ -2089,9 +2089,8 @@ are employees with respect to their employers, are facing a steep asymmetry of p
 are people in some situations of intellectual or psychological impairment, are
 refugees, etc.
 
-A <dfn>context</dfn> is a physical or digital environment that a [=person=] interacts with
-for a set of [=purposes=] (that they typically share with other [=people=] who interact with the
-same environment).
+A <dfn>context</dfn> is a physical or digital environment in which [=people=] interact with other
+[=actors=], and which the [=people=] understand as distinct from other [=contexts=].
 
 ## Server-Side Parties {#parties}
 
@@ -2185,11 +2184,6 @@ planned outcome of this [=processing=] which is achieved or aimed for within a g
 [=context=]. A [=purpose=], when described, should be specific enough to be actionable by
 someone familiar with the relevant [=context=] (ie. they could independently determine
 [=means=] that reasonably correspond to an implementation of the [=purpose=]).
-
-<!--
-XXX given that contexts are defined from *user* purpose we might wish to have purpose in
-general and processing purpose for the above.
--->
 
 The <dfn>means</dfn> are the general method of [=data processing=] through which a given
 [=purpose=] is implemented, in a given [=context=], considered at a relatively abstract


### PR DESCRIPTION
There was a comment in the source that our definition of "context" used "purpose" with a different meaning from the processing-related definition we give it. While trying to clarify our definition, I realized that Dr. Nissenbaum doesn't define "context" anywhere in [Privacy as Contextual Integrity](https://digitalcommons.law.uw.edu/cgi/viewcontent.cgi?article=4450&context=wlr), and I haven't read the books in her citation 67 to find a definition in them. Since she does say it's "firmly rooted in common experience", I tried to use my common experience to explain what we mean.

I think contexts aren't actually divided by the people in them having different reasons to be in the different contexts, but rather just by the people feeling like the contexts are different.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/212.html" title="Last updated on Jan 17, 2023, 11:42 PM UTC (3abab81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/212/0c8f4e5...jyasskin:3abab81.html" title="Last updated on Jan 17, 2023, 11:42 PM UTC (3abab81)">Diff</a>