### PR TITLE
Replace most uses of "party" with "actor", except for 1P, 3P, and 🥳.

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,8 +531,7 @@ These asymmetries of information and of automation create significant asymmetrie
 these [=principles=] constrain and distribute the power of information between different [=actors=].
 Such <dfn>principles</dfn> describe the ways in which different [=actors=] may, must,
 or must not produce or [=process=] flows of information from, to, or about other [=actors=]
-([[?GKC-Privacy]], [[?IAD]]). Typically, <dfn>actors</dfn> are [=people=] but they can also be collective entities such as
-companies, associations, or governmental bodies, which are known as [=parties=].
+([[?GKC-Privacy]], [[?IAD]]).
 
 It is important to keep in mind that not all people are equal in how they can resist
 the imposition of unfair [=principles=]: some [=people=] are more [=vulnerable=] and therefore in greater
@@ -561,19 +560,19 @@ person is in scope, as is [=de-identified=] [=data=] that can be used to manipul
 was extracted by observing people's behaviour on a website.
 
 [=Information flows=] need to be understood from more than one perspective: there is the flow of information
-<em>about</em> a person (the subject) being processed or transmitted to any other party, and there is
+<em>about</em> a person (the subject) being processed or transmitted to any other [=actor=], and there is
 the flow of information <em>towards</em> a person (the recipient). Recipients can have their privacy violated in multiple ways such as
 unexpected shocking images, loud noises while they intend to sleep, manipulative information,
 interruptive messages when their focus is on something else, or harassment when they seek
 social interactions.
 
-On the Web, [=information flows=] may involve a wide variety of [=parties=] that are not always
+On the Web, [=information flows=] may involve a wide variety of [=actors=] that are not always
 recognizable or obvious to a user within a particular interaction. Visiting a website may involve
-the parties that operate that site and its functionality, but also parties with network access,
+the actors that operate that site and its functionality, but also actors with network access,
 which may include: Internet service providers; other network operators; local institutions providing
 a network connection including schools, libraries or universities; government intelligence services;
-malicious hackers who have gained access to the network or the systems of any of the other parties.
-High-level threats including [=surveillance=] may be pursued by these parties. Pervasive monitoring,
+malicious hackers who have gained access to the network or the systems of any of the other actors.
+High-level threats including [=surveillance=] may be pursued by these actors. Pervasive monitoring,
 a form of large-scale, indiscriminate surveillance, is a known attack on the privacy of users of the
 Internet and the Web [[RFC7258]].
 
@@ -585,7 +584,7 @@ people involved in the information flow.
 ## Individual Autonomy {#autonomy}
 
 A [=person=]'s <dfn data-lt="autonomous">autonomy</dfn> is their ability to make decisions of their own personal will,
-without undue influence from other [=parties=]. People have limited intellectual resources and
+without undue influence from other [=actors=]. People have limited intellectual resources and
 time with which to weigh decisions, and by necessity rely on shortcuts when making
 decisions. This makes their preferences, including privacy preferences, malleable and susceptible to
 manipulation ([[?Privacy-Behavior]], [[?Digital-Market-Manipulation]]). A [=person=]'s [=autonomy=] is enhanced by a
@@ -656,7 +655,7 @@ the user with the intent of overriding their global opt-out.
 
 <dfn data-lt="privacy labor|labour|labor">Privacy labour</dfn> is the practice of having a [=person=] carry out
 the work of ensuring [=data processing=] of which they are the subject or recipient is
-[=appropriate=], instead of putting the responsibility on the [=parties=] who are doing the processing.
+[=appropriate=], instead of putting the responsibility on the [=actors=] who are doing the processing.
 Data systems that are based on asking [=people=] for their [=consent=] tend to increase
 [=privacy labour=].
 
@@ -669,15 +668,15 @@ elaborated in the 1970s in support of individual [=autonomy=] in the face of gro
 decision-making. Since they offload the [=privacy labour=]
 to people and assume perfect, unlimited [=autonomy=], the [=FIPs=] do not forbid specific
 types of [=data processing=] but only place them under different procedural requirements.
-Such an approach is [=appropriate=] for [=parties=] that are processing data in the 1970s.
+Such an approach is [=appropriate=] for [=actors=] that are processing data in the 1970s.
 
 One notable issue with procedural, self-governing approaches to privacy is that they tend to have the same
 requirements in situations where people find themselves in a significant asymmetry of
-power with a [=party=] — for instance a [=person=] using an essential service provided by a
-monopolistic platform — and those where people and [=parties=] are very much on equal
+power with another [=actor=] — for instance a [=person=] using an essential service provided by a
+monopolistic platform — and those where a person and the other [=actor=] are very much on equal
 footing, or even where the [=person=] may have greater power, as is the case with small
 businesses operating in a competitive environment. They further do not consider cases in
-which one [=party=] may coerce other [=parties=] into facilitating its [=inappropriate=]
+which one [=actor=] may coerce other [=actors=] into facilitating its [=inappropriate=]
 practices, as is often the case with dominant players in advertising or
 in content aggregation ([[?Consent-Lackeys]], [[?CAT]]).
 
@@ -700,7 +699,7 @@ job ads there. Visitors to that page are implicitly having their [=data=] proces
 ([[?Relational-Governance]]).
 
 What we consider is therefore not just the relation between the [=people=] who share data
-and the [=parties=] that invite that sharing ([[?Relational-Turn]]), but also between the [=people=]
+and the [=actors=] that invite that sharing ([[?Relational-Turn]]), but also between the [=people=]
 who may find themselves categorised indirectly as part of a group even without sharing data. One key
 understanding here is that such relations may persist even when data is [=de-identified=]. What's
 more, such categorisation of people, voluntary or not, changes the way in which the world operates.
@@ -723,7 +722,7 @@ but this requires collective oversight to be [=appropriate=].
 
 There are different ways for [=people=] to become members of a group. Either they can join it
 deliberately, making it a self-constituted group such as when joining a club, or they can be
-classified into it by an external party, typically a bureaucracy or its computerised equivalent
+classified into it by an external actor, typically a bureaucracy or its computerised equivalent
 ([[?Beyond-Individual]]). In the latter case, [=people=] may not be aware that they are being
 grouped together, and the definition of the group may not be intelligible (for instance if it is
 created from opaque machine learning techniques).
@@ -793,7 +792,7 @@ monitoring of their behaviour. Its <dfn class="export">user agent duties</dfn> i
     Protection requires [=user agents=] to actively protect their [=user=]'s data, beyond
     simple security measures. It is insufficient to just encrypt at rest and in transit,
     but the [=user agent=] must also limit retention, help ensure that only strictly
-    necessary data is collected, and require guarantees from any [=party=] that the user agent can
+    necessary data is collected, and require guarantees from any [=actor=] that the user agent can
     reasonably be aware that data is shared to.
   </dd>
   <dt><dfn class="export">Duty of Discretion</dfn></dt>
@@ -980,9 +979,9 @@ fully expect more specific [=contexts=] of the Web to add their own [=principles
 
 To the extent possible, [=user agents=] are expected to enforce these [=principles=]. However, this is not
 always possible and additional enforcement mechanisms are needed. One particularly salient issue
-is that a [=context=] is not defined in terms of who owns or controls it (it is not a [=party=]). Sharing
+is that a [=context=] is not defined in terms of who owns or controls it. Sharing
 [=data=] between different [=contexts=] of a single company is just as much a [=privacy violation=] as
-if the same data were shared between unrelated [=parties=].
+if the same data were shared between unrelated [=actors=].
 
 
 ## Identity on the Web {#identity}
@@ -1196,8 +1195,8 @@ inappropriate information flows.
 ## Data Minimization {#data-minimization}
 
 <div class="practice">
-<span class="practicelab">Sites, user agents, and other parties should minimize the amount of
-<a>personal data</a> they transfer between parties on the Web.</span>
+<span class="practicelab">Sites, user agents, and other actors should minimize the amount of
+<a>personal data</a> they transfer between actors on the Web.</span>
 </div>
 
 Data minimization limits the risks of data being disclosed or misused, and it also helps
@@ -1266,8 +1265,8 @@ privacy</a>). But some people might object anyway, in particular instances or in
 
 <aside class="example">
   Privacy-preserving measurement techniques may be used for aggregate calculations while minimizing
-  the parties that have access to personal data about many individual people. Encryption and
-  privacy-preserving proxies may be used to minimize the parties that have access to personal data or
+  the number of actors that have access to personal data about many individual people. Encryption and
+  privacy-preserving proxies may be used to minimize the number of actors that have access to personal data or
   to hide the contents of personal data used for telemetry or other kinds of measurement. But even
   with those protections, some people may prefer not to participate in some kinds of measurement.
 
@@ -1472,7 +1471,7 @@ a person, consider at least these factors:
 <div class="practice">
   <span class="practicelab" id="respect-data-rights">
     [=People=] have certain rights over [=data=] that is about themselves, and these rights should
-    be facilitated by their [=user agent=] and the [=parties=] that are [=processing=] their
+    be facilitated by their [=user agent=] and the [=actors=] that are [=processing=] their
     [=data=].
   </span>
 </div>
@@ -1493,7 +1492,7 @@ The right to erase applies whether or not terminating use of a service altogethe
 data on their device, on a server, or both, and the distinctions may not always be clear.
 
 * The <dfn data-export="" data-lt="right to portability" data-local-lt="portability">right to
-port</dfn> [=data=], including data one has stored with a [=party=], so it can easily be reused or
+port</dfn> [=data=], including data one has stored with another [=actor=], so it can easily be reused or
 transferred elsewhere.
 
 Portability is needed to realize the ability for [=people=] to make choices about services with
@@ -1553,8 +1552,8 @@ We talk of <dfn>controlled de-identified data</dfn> when:
 
 Different situations involving [=controlled de-identified data=] will require different controls.
 For instance, if the [=controlled de-identified data=] is <em>only</em> being processed by one
-[=party=], typical controls include making sure that the [=identifiers=] used in the data are unique
-to that dataset, that any person (e.g. an employee of the [=party=]) with access to the [=data=] is
+[=actor=], typical controls include making sure that the [=identifiers=] used in the data are unique
+to that dataset, that any person (e.g. an employee of the [=actor=]) with access to the [=data=] is
 barred (e.g. based on legal terms) from sharing the [=data=] further, and that technical measures
 exist to prevent re-identification or the joining of different data sets involving this [=data=],
 notably against timing or k-anonymity attacks.
@@ -1564,12 +1563,12 @@ provides a viable degree of oversight and accountability such that technical and
 guarantee the maintenance of pseudonymity are preserved.
 
 This is more difficult when the [=controlled de-identified data=] is shared between several
-[=parties=]. In such cases, good examples of typical controls that are representative of best
+[=actors=]. In such cases, good examples of typical controls that are representative of best
 practices would include making sure that:
 
-* the [=identifiers=] used in the [=data=] are under the direct and exclusive control of
-  the [=first party=] who is prevented by strict controls from matching the identifiers with the
-  data;
+* the [=identifiers=] used in the [=data=] are under the direct and exclusive control of the [=first
+  party=] (the [=actor=] a person is directly interacting with) who is prevented by strict controls
+  from matching the identifiers with the data;
 
 * when these [=identifiers=] are shared with a [=third party=], they are made unique
   to that [=third party=] such that if they are shared with more than one
@@ -1801,7 +1800,7 @@ more accountable. Examples of mitigations include:
   [=people=] prior to enabling communication.
 * Requiring a deliberate action from the recipient before rendering media coming from an
   untrusted source.
-* Supporting the ability for [=people=] to block a [=party=] such that they cannot send information
+* Supporting the ability for [=people=] to block another [=actor=] such that they cannot send information
   again.
 * Pooling mitigation information, for instance shared block lists, shared spam-detection
   information, or public information about misbehaving [=actors=]. As always, the collection and
@@ -1997,14 +1996,14 @@ or even used to manipulate behaviour and thus reduce [=autonomy=].
 
 <div class="practice">
   <span class="practicelab" id="principle-do-not-retaliate">
-    [=Parties=] must not retaliate against [=people=] who protect their [=data=] against
+    [=Actors=] must not retaliate against [=people=] who protect their [=data=] against
     non-essential [=processing=] or exercise rights over their [=data=].
   </span>
 </div>
 
-Whenever people have the ability to cause a [=party=] to process less of their [=data=] or to stop
+Whenever people have the ability to cause an [=actor=] to process less of their [=data=] or to stop
 carrying out some given set of data processing that is not essential to the service, they must be
-allowed to do so without the [=party=] retaliating, for instance by artificially removing an
+allowed to do so without the [=actor=] retaliating, for instance by artificially removing an
 unrelated feature, by decreasing the quality of the service, or by trying to cajole, badger, or
 trick the [=person=] into opting back into the [=processing=].
 
@@ -2014,12 +2013,12 @@ trick the [=person=] into opting back into the [=processing=].
 
 <div class="practice">
   <span class="practicelab" id="principle-support-choosing-info">
-    [=User agents=] should support [=people=] in choosing which information they provide to [=parties=] that
+    [=User agents=] should support [=people=] in choosing which information they provide to [=actors=] that
     request it, up to and including allowing users to provide arbitrary information.
   </span>
 </div>
 
-[=Parties=] can invest time and energy into automating ways of gathering [=data=] from [=people=] and can
+[=Actors=] can invest time and energy into automating ways of gathering [=data=] from [=people=] and can
 design their products in ways that make it a lot easier for [=people=] to disclose information than not, whereas
 [=people=] typically have to manually wade through options, repeated prompts, and [=deceptive patterns=]. In many
 cases, the absence of data — when a [=person=] refuses to provide some information — can also be identifying
@@ -2113,22 +2112,23 @@ A <dfn>context</dfn> is a physical or digital environment that a [=person=] inte
 for a set of [=purposes=] (that they typically share with other [=people=] who interact with the
 same environment).
 
-## Server-Side Parties {#parties}
+## Server-Side Actors {#parties}
 
-A <dfn>party</dfn> is an entity that a [=person=] can reasonably understand as a single "thing"
-they're interacting with. Uses of this document in a particular domain are expected to describe how
-the core concepts of that domain combine into a [=user=]-comprehensible [=party=], and those refined
-definitions are likely to differ between domains.
+An <dfn>actor</dfn> is an entity that a [=person=] can reasonably understand as a single "thing"
+they're interacting with. [=Actors=] can be [=people=] or collective entities like companies,
+associations, or governmental bodies. Uses of this document in a particular domain are expected to
+describe how the core concepts of that domain combine into a [=user=]-comprehensible [=actor=], and
+those refined definitions are likely to differ between domains.
 
 [=User agents=] tend to explain to [=people=] which [=origin=] or [=site=] provided the
-web page they're looking at. The [=party=] that controls this [=origin=] or [=site=] is
+web page they're looking at. The [=actor=] that controls this [=origin=] or [=site=] is
 known as the web page's <dfn data-dfn-for="page">first party</dfn>. When a [=person=]
 interacts with a UI element on a web page, the <dfn>first party</dfn> of that interaction
-is usually the web page's [=page/first party=]. However, if a different [=party=] controls
+is usually the web page's [=page/first party=]. However, if a different [=actor=] controls
 how data collected with
 the UI element is used, and a reasonable person with a realistic cognitive budget would realize
-that this other [=party=] has this control, this other
-[=party=] is the [=first party=] for the interaction instead.
+that this other [=actor=] has this control, this other
+[=actor=] is the [=first party=] for the interaction instead.
 
 <aside class="issue">
   The group believes that the definition of [=first party=] provided above needs further refinement.
@@ -2137,9 +2137,9 @@ that this other [=party=] has this control, this other
 </aside>
 
 The [=first party=] to an interaction is accountable for the processing of data produced
-by that interaction, even if another party does the processing.
+by that interaction, even if another actor does the processing.
 
-A <dfn data-lt="third parties">third party</dfn> is any [=party=] other than the
+A <dfn data-lt="third parties">third party</dfn> is any [=actor=] other than the
 [=person=] visiting the website or the [=first parties=] they expect to be interacting
 with.
 
@@ -2186,18 +2186,18 @@ followed appropriately. When the [=principles=] for that [=context=] are not fol
 <dfn data-lt="appropriately">appropriate</dfn> when the [=principles=] are adhered
 to) or <dfn data-lt="inappropriately">inappropriate</dfn> otherwise.
 
-A [=party=] <dfn data-lt="process|processing|processed|data processing">processes</dfn> data if it
+An [=actor=] <dfn data-lt="process|processing|processed|data processing">processes</dfn> data if it
 carries out operations on [=personal data=], whether or not by automated means, such as
 collection, recording, organisation, structuring, storage, adaptation or alteration,
 retrieval, consultation, use, disclosure by transmission, [=sharing=], dissemination or
 otherwise making available, [=selling=], alignment or combination, restriction, erasure or
 destruction.
 
-A [=party=] <dfn data-lt="share|sharing">shares</dfn> data if it provides it to any other
-[=party=]. Note that, under this definition, a [=party=] that provides data to its own
+An [=actor=] <dfn data-lt="share|sharing">shares</dfn> data if it provides it to any other
+[=actor=]. Note that, under this definition, an [=actor=] that provides data to its own
 [=service providers=] is not [=sharing=] it.
 
-A [=party=] <dfn data-lt="sell|selling">sells</dfn> data when it [=shares=] it in exchange
+An [=actor=] <dfn data-lt="sell|selling">sells</dfn> data when it [=shares=] it in exchange
 for consideration, monetary or otherwise.
 
 The <dfn>purpose</dfn> of a given [=processing=] of data is an anticipated, intended, or
@@ -2217,22 +2217,23 @@ level and not necessarily all the way down to implementation details. Example:
 <em>a person will have their preferences restored (purpose) by looking up their identifier
 in a preferences store (means)</em>.
 
-A <dfn>data controller</dfn> is a [=party=] that determines the [=means=] and [=purposes=]
-of data processing. Any [=party=] that is not a [=service provider=] is a [=data controller=].
+A <dfn>data controller</dfn> is an [=actor=] that determines the [=means=] and [=purposes=]
+of data processing. Any [=actor=] that is not a [=service provider=] is a [=data controller=].
 
-A <dfn data-lt="data processor">service provider</dfn> or [=data processor=] is considered to be the
-same [=party=] as the [=actor=] contracting it to perform the relevant [=processing=] if it:
+A <dfn data-lt="data processor">service provider</dfn> or [=data processor=] is considered to be in
+the same category of [=first party=] or [=third party=] as the [=actor=] contracting it to
+perform the relevant [=processing=] if it:
 
-* is processing the data on behalf of that [=party=];
+* is processing the data on behalf of that [=actor=];
 * ensures that the data is only retained, accessed, and used as directed by that
-  [=party=] and solely for the list of explicitly-specified [=purposes=]
-  detailed by the directing [=party=] or [=data controller=];
+  [=actor=] and solely for the list of explicitly-specified [=purposes=]
+  detailed by the directing [=actor=] or [=data controller=];
 * may determine implementation details of the data processing in question but
   does not determine the [=purpose=] for which the data is being [=processed=]
   nor the overarching [=means=] through which the [=purpose=] is carried out;
 * has no independent right to use the data other than in a [=de-identified=] form (e.g., for
   monitoring service integrity, load balancing, capacity planning, or billing); and,
-* has a contract in place with the [=party=] which is consistent with the above limitations.
+* has a contract in place with the [=actor=] which is consistent with the above limitations.
 
 </section>
 


### PR DESCRIPTION
Fixes #209.

Our introduction of "first party" is a little awkward in https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/213.html#parties. I'd like to deal with that along with #152, in a separate PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/213.html" title="Last updated on Jan 18, 2023, 12:39 AM UTC (f4914b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/213/0fc6c64...jyasskin:f4914b4.html" title="Last updated on Jan 18, 2023, 12:39 AM UTC (f4914b4)">Diff</a>