### PR TITLE
Discovery 156

### DIFF
--- a/index.html
+++ b/index.html
@@ -1495,9 +1495,10 @@ do support self-determination and help improve accountability. Such rights inclu
 
 * The <dfn data-export="">right to access</dfn> [=data=] about oneself.
 
-This right includes being able to discover data about oneself (implying no databases are kept
-secret) and to review
-what information has been collected or inferred.
+This right includes both being able to review what information has been collected or inferred about
+oneself and being able to discover what [=actors=] have collected information about oneself. As a
+result, databases must not be kept secret and data collected about [=people=] must be meaningfully
+discoverable by those people.
 
 * The <dfn data-export="" data-lt="right to erase">right to erase</dfn> [=data=] about oneself.
 

--- a/index.html
+++ b/index.html
@@ -1497,7 +1497,7 @@ do support self-determination and help improve accountability. Such rights inclu
 
 This right includes both being able to review what information has been collected or inferred about
 oneself and being able to discover what [=actors=] have collected information about oneself. As a
-result, databases must not be kept secret and data collected about [=people=] must be meaningfully
+result, databases cannot be kept secret and data collected about [=people=] needs to be meaningfully
 discoverable by those people.
 
 * The <dfn data-export="" data-lt="right to erase">right to erase</dfn> [=data=] about oneself.

--- a/index.html
+++ b/index.html
@@ -47,6 +47,13 @@
         }
       ],
       localBiblio: {
+        'Addressing-Cyber-Harassment': {
+          title: 'Addressing cyber harassment: An overview of hate crimes in cyberspace',
+          authors: ['Danielle Keats Citron'],
+          publisher: 'Case Western Reserve Journal of Law, Technology & the Internet',
+          date: '2015',
+          href: 'https://scholarship.law.bu.edu/cgi/viewcontent.cgi?article=1634&context=faculty_scholarship'
+        },
         'Anti-Tracking-Policy': {
           title: 'Anti-Tracking Policy',
           href: 'https://wiki.mozilla.org/Security/Anti_tracking_policy#Tracking_Definition',
@@ -202,6 +209,13 @@
           authors: ['Ari Ezra Waldman'],
           href: 'https://www.cambridge.org/core/books/industry-unbound/787989F90DBFC08E47546178A7AB04F7',
           publisher: 'Cambridge University Press',
+        },
+        'Internet-of-Garbage': {
+          title: 'The Internet of Garbage',
+          authors: ['Sarah Jeong'],
+          publisher: 'The Verge',
+          date: '2018',
+          href: 'https://www.theverge.com/2018/8/28/17777330/internet-of-garbage-book-sarah-jeong-online-harassment'
         },
         'Lost-In-Crowd': {
           title: 'Why You Can No Longer Get Lost in the Crowd',


### PR DESCRIPTION
Clarify language on access right to make it explicit that databases must not be kept secret and people must have the meaningful ability to discover what actors are collecting what data about them.

Clarification was noted as a need in #156, which this PR is intended to address.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#data-rights
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/219.html#data-rights" title="Last updated on Jan 27, 2023, 1:08 AM UTC (ad0a535)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/219/d9fd32a...ad0a535.html" title="Last updated on Jan 27, 2023, 1:08 AM UTC (ad0a535)">Diff</a>