### PR TITLE
remove list of privacy labor suggestions around ancillary data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1265,9 +1265,7 @@ privacy</a>).
 
 [=User agents=] should aggressively <a href="#data-minimization">minimize</a> [=ancillary
 data=] and should avoid burdening the user with additional [=privacy labor=]
-when deciding what [=ancillary data=] to expose. To that end, user agents may
-employ user research, solicitation of general preferences, and heuristics about
-sensitivity of data or trust in a particular context. To facilitate site
+when deciding what [=ancillary data=] to expose. To facilitate site
 understanding of user preferences, user agents can provide browser-configurable
 signals to directly communicate common user preferences (such as a [=global
 opt-out=]).


### PR DESCRIPTION
Remove list of suggestions around privacy labor and ancillary data. 

I also think it'd be fine to solve #220 by being more specific about how browsers could prevent privacy labor around ancillary data collection w/o collecting ancillary data from users who dont want to or anticipate that data collection


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#ancillary-uses
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/221.html#ancillary-uses" title="Last updated on May 11, 2023, 12:45 AM UTC (e2aa4bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/221/d52ee70...e2aa4bd.html" title="Last updated on May 11, 2023, 12:45 AM UTC (e2aa4bd)">Diff</a>