### PR TITLE
Change 'send' to 'expose' in the ancillary data section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1263,9 +1263,9 @@ privacy</a>).
   goals and preferences about use of data about them.</span>
 </div>
 
-Agents should aggressively <a href="#data-minimization">minimize</a> [=ancillary
+[=User agents=] should aggressively <a href="#data-minimization">minimize</a> [=ancillary
 data=] and should avoid burdening the user with additional [=privacy labor=]
-when deciding what [=ancillary data=] to send. To that end, user agents may
+when deciding what [=ancillary data=] to expose. To that end, user agents may
 employ user research, solicitation of general preferences, and heuristics about
 sensitivity of data or trust in a particular context. To facilitate site
 understanding of user preferences, user agents can provide browser-configurable


### PR DESCRIPTION
@yoavweiss was worried that the existing wording put constraints on Web Perf APIs that it didn't put on alternate ways the platform exposes the same data. We think changing this word avoids the problem.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/222.html" title="Last updated on Feb 27, 2023, 5:32 PM UTC (0247538)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/222/cbadea7...jyasskin:0247538.html" title="Last updated on Feb 27, 2023, 5:32 PM UTC (0247538)">Diff</a>