### PR TITLE
Start making the opt in/out section consistently talk about purposes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,10 +649,13 @@ however, they are used as a way to avoid putting in the difficult work of decidi
 types of [=processing=] are [=appropriate=] and which are not, offloading [=privacy labour=]
 to the people using a system.
 
-In specific cases, [=people=] should be able to [=consent=] to more
-sensitive [=purposes=], such as having their [=identity=] recognised across contexts or
-their reading history shared with a company. The burden of proof on ensuring that informed
-[=consent=] has been obtained needs to be very high in this case.
+[=People=] should be able to [=consent=] to specific [=purposes=] that would
+otherwise be restricted, such as logging into one site with an identity from a
+different one, or using their reading history to target ads. [=Actors=] need to
+take care that their users are *informed* when granting this [=consent=] and
+*aware* enough about what's going on that they can know to revoke their consent
+when they want to.
+
 [=Consent=] is comparable to the general problem of permissions on the Web
 platform. Both consent and permissions should be requested in a way that lets
 people delay or avoid answering if they're trying to do something else. If


### PR DESCRIPTION
And avoid calling some purposes more sensitive than others.

This attempts to fix #229. When writing it, I realized that @michaelkleber was right that the [first paragraph](https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/236.html#opt-in-out) here says that consent is about purposes rather than just data sharing, so it didn't make sense to use the [phrasing we sketched yesterday](https://github.com/w3ctag/privacy-principles/issues/229#issuecomment-1479981172).

The paragraph after this one still talks about data sharing, but I'd like to adjust that once we've made some more progress on #230.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#opt-in-out
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/236.html#opt-in-out" title="Last updated on May 3, 2023, 11:25 PM UTC (710cab6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/236/6b09507...jyasskin:710cab6.html" title="Last updated on May 3, 2023, 11:25 PM UTC (710cab6)">Diff</a>