### PR TITLE
Use Infra's definition of "user agent".

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,7 +430,7 @@
     }
   </style>
 </head>
-<body data-cite="html indexedDB service-workers fingerprinting-guidance url">
+<body data-cite="html indexedDB service-workers fingerprinting-guidance url infra">
 
 <section id="abstract">
 
@@ -781,7 +781,7 @@ decisions.
 
 ## People's Agents {#user-agents}
 
-The <dfn>user agent</dfn> acts as an intermediary between a [=person=] (its [=user=]) and the web.
+A [=user agent=] acts as an intermediary between a [=person=] (its [=user=]) and the web.
 [=User agents=] implement, to the extent possible, the [=principles=] that collective governance
 establishes in favour of individuals. They seek to prevent the creation of asymmetries of
 information, and serve their [=user=] by providing them with automation to rectify


### PR DESCRIPTION
@jbradleychen had to read our text a couple times to figure out that "user agent" referred to software. We have a reasonable [definition](https://infra.spec.whatwg.org/#user-agent) in Infra, and our `<dfn>` didn't read like a definition, so let's refer to Infra instead.