### PR TITLE
Processing is sensitive, not purposes

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,7 +642,7 @@ defaults and choice architectures.
 
 Several kinds of mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
-their [=data=] is being [=processed=] or the amount  their [=data=] is [=processed=]
+their [=data=] is being [=processed=] or the amount their [=data=] is [=processed=]
 are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms
 that decrease this number of [=purposes=] or amount of [=processing=] are known as
 <dfn data-lt="opt out">opt-out</dfn>.

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@ defaults and choice architectures.
 Several kinds of mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
 their [=data=] is being [=processed=] or the amount their [=data=] is [=processed=]
-are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms
+are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>. Mechanisms
 that decrease this number of [=purposes=] or amount of [=processing=] are known as
 <dfn data-lt="opt out">opt-out</dfn>.
 

--- a/index.html
+++ b/index.html
@@ -627,7 +627,7 @@ Different procedural mechanisms exist to enable [=people=] to control how they i
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
 their [=data=] is being [=processed=] or the amount  their [=data=] is [=processed=]
 are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms
-that decrease this number of [=purposes=] or [=processing=] volume are known as
+that decrease this number of [=purposes=] or amount of [=processing=] are known as
 <dfn data-lt="opt out">opt-out</dfn>.
 
 When deployed thoughtfully, these mechanisms can enhance [=people=]'s [=autonomy=]. Often,

--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@ defaults and choice architectures.
 
 Different procedural mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
-their [=data=] is being [=processed=] or the volume of [=processing=] of their [=data=]
+their [=data=] is being [=processed=] or the amount  their [=data=] is [=processed=]
 are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms
 that decrease this number of [=purposes=] or [=processing=] volume are known as
 <dfn data-lt="opt out">opt-out</dfn>.

--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@ defaults and choice architectures.
 
 ### Opt-in, Consent, Opt-out, Global Controls {#opt-in-out}
 
-Different procedural mechanisms exist to enable [=people=] to control how they interact
+Different mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
 their [=data=] is being [=processed=] or the amount  their [=data=] is [=processed=]
 are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms

--- a/index.html
+++ b/index.html
@@ -635,9 +635,13 @@ types of [=processing=] are [=appropriate=] and which are not, offloading [=priv
 to the people using a system.
 
 In specific cases, [=people=] should be able to [=consent=] to more
-sensitive [=purposes=], such as having their [=identity=] recognised across contexts or
-their reading history shared with a company. The burden of proof on ensuring that informed
-[=consent=] has been obtained needs to be very high in this case.
+sensitive [=processing=], such as having their [=identity=] recognised across contexts or
+their reading history shared with a company. [=Actors=] need to
+take care that their users are *informed* when granting this [=consent=] and
+*aware* enough about what's going on that they can know to revoke their consent
+when they want to. They should also ensure that they assess the risk of what *could* be done
+with the data they are collecting or sharing, not just what the stated purpose of that collection
+or sharing is.
 [=Consent=] is comparable to the
 general problem of permissions on the Web platform. In the same way that it should be clear when a
 given device capability is in use (eg. you are providing geolocation or camera access), sharing

--- a/index.html
+++ b/index.html
@@ -640,7 +640,7 @@ defaults and choice architectures.
 
 ### Opt-in, Consent, Opt-out, Global Controls {#opt-in-out}
 
-Different mechanisms exist to enable [=people=] to control how they interact
+Several kinds of mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
 their [=data=] is being [=processed=] or the amount  their [=data=] is [=processed=]
 are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms

--- a/index.html
+++ b/index.html
@@ -656,9 +656,7 @@ In specific cases, [=people=] should be able to [=consent=] to data sharing that
 such as having their [=identity=] or reading history shared across contexts.
 [=Actors=] need to take care that their users are *informed* when granting this [=consent=] and
 *aware* enough about what's going on that they can know to revoke their consent
-when they want to. They should also ensure that they assess the risk of what *could* be done
-with the data they are collecting or sharing, not just what the stated purpose of that collection
-or sharing is.
+when they want to.
 [=Consent=] is comparable to the general problem of permissions on the Web
 platform. Both consent and permissions should be requested in a way that lets
 people delay or avoid answering if they're trying to do something else. If

--- a/index.html
+++ b/index.html
@@ -625,8 +625,9 @@ defaults and choice architectures.
 
 Different procedural mechanisms exist to enable [=people=] to control how they interact
 with systems in the world. Mechanisms that increase the number of [=purposes=] for which
-their [=data=] is being [=processed=] are referred to as [=opt-in=] or
-<dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms that decrease this number of [=purposes=] are known as
+their [=data=] is being [=processed=] or the volume of [=processing=] of their [=data=]
+are referred to as [=opt-in=] or <dfn data-lt="opt in|opt-in">consent</dfn>; mechanisms
+that decrease this number of [=purposes=] or [=processing=] volume are known as
 <dfn data-lt="opt out">opt-out</dfn>.
 
 When deployed thoughtfully, these mechanisms can enhance [=people=]'s [=autonomy=]. Often,
@@ -634,10 +635,9 @@ however, they are used as a way to avoid putting in the difficult work of decidi
 types of [=processing=] are [=appropriate=] and which are not, offloading [=privacy labour=]
 to the people using a system.
 
-In specific cases, [=people=] should be able to [=consent=] to more
-sensitive [=processing=], such as having their [=identity=] recognised across contexts or
-their reading history shared with a company. [=Actors=] need to
-take care that their users are *informed* when granting this [=consent=] and
+In specific cases, [=people=] should be able to [=consent=] to data sharing that would otherwise be restricted,
+such as having their [=identity=] or reading history shared across contexts.
+[=Actors=] need to take care that their users are *informed* when granting this [=consent=] and
 *aware* enough about what's going on that they can know to revoke their consent
 when they want to. They should also ensure that they assess the risk of what *could* be done
 with the data they are collecting or sharing, not just what the stated purpose of that collection


### PR DESCRIPTION
This is intended as a replacement for #236 and a fix for #229.

This:
- Makes it clear that it's processing and not purposes that are sensitive.
- Keeps the language about actors that #236 added.
- Removes "burden of proof" and replaces it with a brief description of risk assessment. (I don't think we want to go into details about impact assessment methodologies.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/242.html" title="Last updated on May 31, 2023, 4:10 PM UTC (b4f1d6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/242/b232917...b4f1d6d.html" title="Last updated on May 31, 2023, 4:10 PM UTC (b4f1d6d)">Diff</a>