### PR TITLE
Replace the reference for "fiduciary".

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,10 +164,12 @@
           authors: ['European Commission'],
           href: 'https://ec.europa.eu/COMMFrontOffice/publicopinion/index.cfm/Survey/getSurveyDetail/instruments/FLASH/surveyKy/2124',
         },
-        'Fiduciary-UA': {
-          title: 'The Fiduciary Duties of User Agents',
-          href: 'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3827421',
-          authors: ['Robin Berjon'],
+        'Fiduciary-Model': {
+          title: 'The Fiduciary Model of Privacy',
+          href: 'https://ssrn.com/abstract=3700087',
+          authors: ['Jack M. Balkin'],
+          date: '26 September 2020',
+          publisher: 'Harvard Law Review Forum'
         },
         'FIP': {
           title: 'Fair Information Practices: A Basic History',
@@ -847,8 +849,8 @@ monitoring of their behaviour. Its <dfn class="export">user agent duties</dfn> i
 </dl>
 
 These duties ensure the [=user agent=] will <em>care</em> for its [=user=]. In academic
-research, this relationship with a [=trustworthy agent=] is often described as "fiduciary"
-[[?Fiduciary-UA]]. Some jurisdictions may have a distinct legal meaning for "fiduciary."
+research, this relationship with a [=trustworthy agent=] has been described as "fiduciary"
+[[?Fiduciary-Model]]. Some jurisdictions may have a distinct legal meaning for "fiduciary."
 
 Many of the [=principles=] described in the rest of this document extend the [=user agent=]'s duties and
 make them more precise.


### PR DESCRIPTION
Fixes #240.

cc/ @michaelkleber


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#bib-fiduciary-model
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/245.html#bib-fiduciary-model" title="Last updated on Apr 5, 2023, 11:51 PM UTC (bab5efb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/245/2832c2c...jyasskin:bab5efb.html" title="Last updated on Apr 5, 2023, 11:51 PM UTC (bab5efb)">Diff</a>