### PR TITLE
Identify what makes print less likely to violate group privacy than the web.

### DIFF
--- a/index.html
+++ b/index.html
@@ -706,11 +706,6 @@ of [=privacy=] in a given context can be
 contested ([[?Privacy-Contested]]). This makes privacy a problem of collective action ([[?GKC-Privacy]]).
 Group-level [=data processing=] may impact populations or individuals, including in
 ways that [=people=] could not control even under the optimistic assumptions of [=consent=].
-For example, based on group-level analysis, a company may know that <var>Niche
-Magazine</var> or <var>site.example</var> is predominantly read by [=people=]
-of a given race or gender, and decide not to run its job ads there. Readers of
-those publications are implicitly having their [=data=] processed in
-[=inappropriate=] ways ([[?Relational-Governance]]).
 
 What we consider is therefore not just the relation between the [=people=] who share data
 and the [=actors=] that invite that sharing ([[?Relational-Turn]]), but also between the [=people=]

--- a/index.html
+++ b/index.html
@@ -706,11 +706,11 @@ of [=privacy=] in a given context can be
 contested ([[?Privacy-Contested]]). This makes privacy a problem of collective action ([[?GKC-Privacy]]).
 Group-level [=data processing=] may impact populations or individuals, including in
 ways that [=people=] could not control even under the optimistic assumptions of [=consent=].
-For example, based on group-level analysis, a company may know that <var>site.example</var>
-is predominantly visited by [=people=] of a given race or gender, and decide not to run its
-job ads there. Visitors to that page are implicitly having their [=data=] processed in
-[=inappropriate=] ways, with no way to discover the discrimination or seek relief
-([[?Relational-Governance]]).
+For example, based on group-level analysis, a company may know that <var>Niche
+Magazine</var> or <var>site.example</var> is predominantly read by [=people=]
+of a given race or gender, and decide not to run its job ads there. Readers of
+those publications are implicitly having their [=data=] processed in
+[=inappropriate=] ways ([[?Relational-Governance]]).
 
 What we consider is therefore not just the relation between the [=people=] who share data
 and the [=actors=] that invite that sharing ([[?Relational-Turn]]), but also between the [=people=]
@@ -720,9 +720,11 @@ more, such categorisation of people, voluntary or not, changes the way in which 
 This can produce self-reinforcing loops that can damage both individuals and
 groups ([[?Seeing-Like-A-State]]).
 
-In general, collective issues in [=data=] require collective solutions. Web standards help with
-[=data governance=] by defining structural controls
-in [=user agents=] and establishing or delegating to institutions that can handle issues of [=privacy=].
+In general, collective issues in [=data=] require collective solutions.
+Web standards help with [=data governance=] by
+defining structural controls in [=user agents=],
+ensuring that researchers and regulators can discover group-level abuse,
+and establishing or delegating to institutions that can handle issues of [=privacy=].
 [=Governance=] will often struggle to achieve its goals if it works primarily by
 increasing <em>individual</em> control instead of by collective action.
 


### PR DESCRIPTION
While advertisers can easily buy ads in particular publications to
target groups of users, a researcher can look at the content of those
publications to see the same content that's shown to all readers.
Online, each visitor can see a different set of ads, so we need other
mechanisms to help researchers discover problems. Web standards can
define those mechanisms.

This tries to fix #235. How'd I do, @michaelkleber?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#collective
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/248.html#collective" title="Last updated on Apr 12, 2023, 4:50 PM UTC (cda2b1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/248/4b06c6c...jyasskin:cda2b1b.html" title="Last updated on Apr 12, 2023, 4:50 PM UTC (cda2b1b)">Diff</a>