### PR TITLE
Avoid saying that safety systems have to describe how to exploit them.

### DIFF
--- a/index.html
+++ b/index.html
@@ -894,9 +894,7 @@ This is a special case of the more general principle that data should not be use
 [=purposes=] than the data's subjects understood it was being collected for.
 
 Services sometimes use people's data in order to protect those or other people.
-This is legitimate as long as the extra risk created by the data collection is
-less than the protection it offers and the extra risk isn't concentrated on
-[=vulnerable people=]. A service that does this should explain what data it's
+A service that does this should explain what data it's
 using for this purpose. It should also say how it might use or share a person's
 data if it believes that person has broken the rules.
 

--- a/index.html
+++ b/index.html
@@ -893,9 +893,12 @@ for other purposes, like to grow the service.</span></p>
 This is a special case of the more general principle that data should not be used for more
 [=purposes=] than the data's subjects understood it was being collected for.
 
-A service should explain how it uses people's data to protect them and other people, and
-how it might additionally use someone's data if it believes that person has broken the
-rules.
+Services sometimes use people's data in order to protect those or other people.
+This is legitimate as long as the extra risk created by the data collection is
+less than the protection it offers and the extra risk isn't concentrated on
+[=vulnerable people=]. A service that does this should explain what data it's
+using for this purpose. It should also say how it might use or share a person's
+data if it believes that person has broken the rules.
 
 </div>
 


### PR DESCRIPTION
The text I originally wrote here got interpreted as saying that services
have to explain all the details of how they use data to fight fraud,
which of course would help the fraudsters avoid detection. Instead, we
meant just that the service should say what kinds of things it's
collecting in order to protect people.

I also got a comment on how abrupt this paragraph is, since it just
restricts the safety-related data collection without saying that this
purpose is reasonable in the first place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/249.html" title="Last updated on Apr 12, 2023, 4:50 PM UTC (3f4b834)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/249/4b06c6c...jyasskin:3f4b834.html" title="Last updated on Apr 12, 2023, 4:50 PM UTC (3f4b834)">Diff</a>