### PR TITLE
Fix capitalisation of JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,7 +1346,7 @@ information into three categories:
         they clicked to leave that page. We can't block that information
         because the page can use <a data-cite="RFC9110#status.3xx">HTTP redirects</a> to
         learn it, and redirection is a core feature of the web.
-    * Some users are disappointed that a page with permission to run Javascript can record
+    * Some users are disappointed that a page with permission to run JavaScript can record
         their pattern of interaction with that page. However, the page does this by using
         the same events it would use to make the page interactive, so we can't block this
         information access either.
@@ -1374,7 +1374,7 @@ Acceptable information exposure is always qualified by the (possibly empty) set 
 user-controlled settings or permissions that <dfn data-lt="access guard">guard</dfn> access to it.
 For example, the URLs of resources, the timing of link clicks, and the referrer chain within a
 single origin are not guarded by anything; the scroll position is guarded by the setting to turn off
-javascript; and access to the camera or geolocation are guarded by permission prompts.
+JavaScript; and access to the camera or geolocation are guarded by permission prompts.
 
 Information that would be acceptable to expose under one set of [=access guards=] might be
 unacceptable under another set, so when an API designer intends to explain that their new


### PR DESCRIPTION
I found a couple of places where "JavaScript" isn't capitalised correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/privacy-principles/pull/259.html" title="Last updated on Apr 24, 2023, 7:35 PM UTC (92748f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/259/4e4732c...chrisn:92748f5.html" title="Last updated on Apr 24, 2023, 7:35 PM UTC (92748f5)">Diff</a>