### PR TITLE
Avoid defining "principles" with a different meaning than in the title of the document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,31 +555,31 @@ the victim.
 
 These asymmetries of information and of automation create significant asymmetries of power.
 
-<dfn data-lt="governance">Data governance</dfn> is the system of [=principles=] that regulate [=information flows=]. When
+<dfn data-lt="governance">Data governance</dfn> is the system of principles that regulate [=information flows=]. When
 [=people=] are involved in [=information flows=], [=data governance=] determines how
-these [=principles=] constrain and distribute the power of information between different [=actors=].
-Such <dfn>principles</dfn> describe the ways in which different [=actors=] may, must,
+these principles constrain and distribute the power of information between different [=actors=].
+Such principles describe the ways in which different [=actors=] may, must,
 or must not produce or [=process=] flows of information from, to, or about other [=actors=]
 ([[?GKC-Privacy]], [[?IAD]]).
 
 It is important to keep in mind that not all people are equal in how they can resist
-the imposition of unfair [=principles=]: some [=people=] are more [=vulnerable=] and therefore in greater
+the imposition of unfair principles: some [=people=] are more [=vulnerable=] and therefore in greater
 need of protection. This document focuses on the impact that differences in information power can
 have on people, but those differences can also impact other [=actors=], such as companies or governments.
 
-[=Principles=] vary from [=context=] to [=context=] ([[?Understanding-Privacy]], [[?Contextual-Integrity]]): people
+Principles vary from [=context=] to [=context=] ([[?Understanding-Privacy]], [[?Contextual-Integrity]]): people
 have different expectations of [=privacy=] at work, at a café, or at home for instance. Understanding and
 evaluating a privacy situation is best done by clearly identifying:
 
 * Its [=actors=], which include the subject of the information as well as the sender and the recipient
   of the [=information flow=]. (Note that recipients might not always want to be recipients.)
 * The type of data involved in the [=information flow=].
-* The [=principles=] that are in use in this context.
+* The principles that are in use in this context.
 
-It is important to keep in mind that there are <em>always</em> privacy [=principles=] and that all
-of them imply different power dynamics. Some sets of [=principles=] may be more permissive, but that does
+It is important to keep in mind that there are <em>always</em> privacy principles and that all
+of them imply different power dynamics. Some sets of principles may be more permissive, but that does
 not make them neutral — it means that they support the power dynamic that
-comes with permissive [=processing=]. We must therefore determine which [=principles=]
+comes with permissive [=processing=]. We must therefore determine which principles
 best align with ethical Web values in Web [=contexts=] ([[?ETHICAL-WEB]], [[?Why-Privacy]]).
 
 <dfn data-lt='information'>Information flows</dfn> as used in this document refer to information
@@ -715,7 +715,7 @@ and choice</i>", which, in today's digital environment, is often an indication t
 
 ## Collective Governance {#collective}
 
-Privacy [=principles=] are defined through social processes and, because of that, the applicable definition
+Privacy principles are defined through social processes and, because of that, the applicable definition
 of [=privacy=] in a given context can be
 contested ([[?Privacy-Contested]]). This makes privacy a problem of collective action ([[?GKC-Privacy]]).
 Group-level [=data processing=] may impact populations or individuals, including in
@@ -780,7 +780,7 @@ carefully considered by people building websites.
 
 While transparency rarely helps enough to inform the individual choices that [=people=] may
 make, it plays a critical role in letting researchers and reporters inform our
-collective decision-making about privacy [=principles=]. This consideration extends the
+collective decision-making about privacy principles. This consideration extends the
 TAG's resolution on a [Strong and Secure Web Platform](https://www.w3.org/blog/2015/11/strong-web-platform-statement/)
 to ensure that "<i>broad testing and audit continues to be possible</i>" where
 [=information flows=] and automated decisions are involved.
@@ -793,7 +793,7 @@ decisions.
 ## People's Agents {#user-agents}
 
 A [=user agent=] acts as an intermediary between a [=person=] (its [=user=]) and the web.
-[=User agents=] implement, to the extent possible, the [=principles=] that collective governance
+[=User agents=] implement, to the extent possible, the principles that collective governance
 establishes in favour of individuals. They seek to prevent the creation of asymmetries of
 information, and serve their [=user=] by providing them with automation to rectify
 [=automation asymmetries=]. Where possible, they protect their [=user=] from receiving
@@ -823,7 +823,7 @@ monitoring of their behaviour. Its <dfn class="export">user agent duties</dfn> i
   <dt><dfn class="export">Duty of Discretion</dfn></dt>
   <dd>
     Discretion requires the [=user agent=] to make best efforts to enforce
-    [=principles=] by taking care in the ways it discloses the [=personal data=]
+    principles by taking care in the ways it discloses the [=personal data=]
     that it manages. Discretion is not
     confidentiality or secrecy: trust
     can be preserved even when the [=user agent=] shares some [=personal data=], so long as
@@ -863,7 +863,7 @@ research, this relationship with a [=trustworthy agent=] is often described as "
 see [[?Fiduciary-UA]] for a longer informal discussion). Some jurisdictions may have a distinct
 legal meaning for "fiduciary." ([[?Fiduciary-Law]])
 
-Many of the [=principles=] described in the rest of this document extend the [=user agent=]'s duties and
+Many of the principles described in the rest of this document extend the [=user agent=]'s duties and
 make them more precise.
 
 ## Incorporating Different Privacy Principles {#balancing}
@@ -1000,12 +1000,12 @@ the success of advertising campaigns. Even this small amount of information is s
 
 # Principles for Privacy on the Web
 
-As indicated above, different [=contexts=] require different [=principles=]. This section describes a set
-of [=principles=] designed to apply to the Web [=context=] in general. The Web is a big place, and we
-fully expect more specific [=contexts=] of the Web to add their own [=principles=] to further constrain
+As indicated above, different [=contexts=] require different principles. This section describes a set
+of principles designed to apply to the Web [=context=] in general. The Web is a big place, and we
+fully expect more specific [=contexts=] of the Web to add their own principles to further constrain
 [=information flows=].
 
-To the extent possible, [=user agents=] are expected to enforce these [=principles=]. However, this is not
+To the extent possible, [=user agents=] are expected to enforce these principles. However, this is not
 always possible and additional enforcement mechanisms are needed. One particularly salient issue
 is that a [=context=] is not defined in terms of who owns or controls it. Sharing
 [=data=] between different [=contexts=] of a single company is just as much a [=privacy violation=] as
@@ -1064,8 +1064,8 @@ that they intended to use a single identity, it is [=inappropriate=] to
 information to help with cross-context recognition.
 
 Systems which [=recognize=] people across [=contexts=] need
-to be careful not to apply the [=principles=] of one [=context=] in ways that
-violate the [=principles=] around use of information acquired in a different
+to be careful not to apply the principles of one [=context=] in ways that
+violate the principles around use of information acquired in a different
 [=context=]. This is particularly true for [=vulnerable=] people, as
 recognising them in different [=contexts=] may force traits into the open
 that reveal their vulnerability. For example, if you meet your therapist at a
@@ -2160,10 +2160,10 @@ If a [=person=] could reasonably be identified or re-identified through the comb
 [=data=], then that [=data=] is [=personal data=].
 
 <dfn>Privacy</dfn> is achieved in a given [=context=] that either involves [=personal data=] or
-involves information being presented to [=people=] when the [=principles=] of that [=context=] are
-followed appropriately. When the [=principles=] for that [=context=] are not followed, there is a
+involves information being presented to [=people=] when the principles of that [=context=] are
+followed appropriately. When the principles for that [=context=] are not followed, there is a
 <dfn>privacy violation</dfn>. Similarly, we say that a particular interaction is
-<dfn data-lt="appropriately">appropriate</dfn> when the [=principles=] are adhered
+<dfn data-lt="appropriately">appropriate</dfn> when the principles are adhered
 to) or <dfn data-lt="inappropriately">inappropriate</dfn> otherwise.
 
 An [=actor=] <dfn data-lt="process|processing|processed|data processing">processes</dfn> data if it


### PR DESCRIPTION
Fixes #260.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/264.html" title="Last updated on May 3, 2023, 11:51 PM UTC (25d2902)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/264/6b09507...jyasskin:25d2902.html" title="Last updated on May 3, 2023, 11:51 PM UTC (25d2902)">Diff</a>