### PR TITLE
Clarifying identity vs legal identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@ remain anonymous. We refer to this as "group privacy." Conversely, [=people=] ma
 knowledge that they are members of the group even though the existence of the group and its actions
 may be well known (eg. membership in a dissidents movement under authoritarian rule), which we call
 "membership privacy". An example [=privacy violation=] for the former case
-is the fitness app Strava that did not reveal individual behaviour or identity but published heat
+is the fitness app Strava that did not reveal individual behaviour or [=legal identity=] but published heat
 maps of popular running routes. In doing so, it revealed secret US bases around which military
 personnel took frequent runs ([[?Strava-Debacle]], [[?Strava-Reveal-Military]]).
 
@@ -1030,10 +1030,16 @@ contexts. People may also wish to present an ephemeral or anonymous identity,
 which is just a set of characteristics that is too small or unstable to be useful
 for following them through time.
 
+It is important to keep in mind that a person's [=identity=] may differ from their
+[=legal identity=]. A [=person=]'s <dfn>legal identity</dfn> is the set of characteristics
+that a governmental or otherwise official entity recognizes as corresponding to that
+[=person=].
+
 <dfn data-lt="recognize|recognized">Recognition</dfn> is the act of realising that a given [=identity=]
 corresponds to the same [=person=] as another [=identity=] which may have been
 observed either in another [=context=] or in the same [=context=] but at a
-different time.
+different time. A [=person=] is [=recognized=] whether or not their [=legal identity=] or
+characteristics of their [=legal identity=] are included in the recognition.
 
 In order to uphold the above <a
 href="#principle-identity-per-context">principle</a>, sometimes a [=user agent=]


### PR DESCRIPTION
This clarifies somewhat our use of identity and makes the distinction with legal identity explicit. Fixes #226.