### PR TITLE
No excuses for fingerprinting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1188,11 +1188,7 @@ For example:
 Preventing [=fingerprinting=] can be particularly challenging in cases that
 only affect a small group of people who use the web. For example, people who
 configure their systems in unique ways, such as by using a browser with a very
-small number of users. As long as a tracker can't track a significant number
-of people, it's likely to be unviable to maintain the tracker. However, this
-doesn't excuse making small groups of people trackable when those people
-didn't choose to be in the group.
-
+small number of users.
 See [[fingerprinting-guidance]] for how to mitigate threats that result from
 [=fingerprinting=].
 


### PR DESCRIPTION
The notion that fingerprinting might not be economically feasible doesn't really help anyone.  On the one hand, it just tends to create an excuse for lazy web designers who might choose to neglect fingerprinting protection on the basis that "it won't be viable to exploit this" (tip: it probably is viable).  On the other, the admonition about people who didn't ask to be treated that way is already implied.y

Also, the document has enough words in it already.  No point playing both sides here.

I considered saying something more in place of this, but the paragraph is already complete as is.  That is, it talks about the challenges inherent with fingerprinting in that it disproportionately affects those smaller groupings that tend to form around less mainstream choices or characteristics.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/privacy-principles/pull/275.html" title="Last updated on Jun 27, 2023, 4:47 AM UTC (9e423b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/275/5286a4e...martinthomson:9e423b3.html" title="Last updated on Jun 27, 2023, 4:47 AM UTC (9e423b3)">Diff</a>