### PR TITLE
Grammar fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1632,8 +1632,8 @@ of social equality ([[?Relational-Governance]]).
 Another case in which collective decision-making is preferable is for [=processing=] for which
 informed individual decision-making is unrealistic (due to the complexity of the processing, the
 volume or frequency of processing, or both). Expecting laypeople (or even experts) to make informed
-decisions relating to complex [=data=] [=processing=] or to make decisions on a very frequent basis
-even if the [=processing=] is relatively simple, is unrealistic if we also want them to have
+decisions relating to complex [=data=] [=processing=] or to make decisions on a very frequent
+basis — even if the [=processing=] is relatively simple — is unrealistic if we also want them to have
 reasonable levels of [=autonomy=] in making these decisions.
 
 The purpose of this principle is to require that [=data governance=] provide ways to distinguish


### PR DESCRIPTION
That comma annoyed me.  I think that this is better.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/privacy-principles/pull/286.html" title="Last updated on Jun 27, 2023, 6:56 AM UTC (39ec4b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/286/5286a4e...martinthomson:39ec4b9.html" title="Last updated on Jun 27, 2023, 6:56 AM UTC (39ec4b9)">Diff</a>