### PR TITLE
principle for non-user privacy, to be able to access and remove data uploaded by others

### DIFF
--- a/index.html
+++ b/index.html
@@ -1955,15 +1955,13 @@ Examples of alternatives to interrupting users with consent requests include:
 <div class="practice">
 <p>
   <span class="practicelab" id="principle-consent-withdraw">
-  It should be as easy for a [=person=] to check what consent they have given,
-	to withdraw consent, or to opt out or object,
-	as to give consent.
+  It should be as easy for a [=person=] to check what consent they have given, to withdraw consent,
+  or to opt out or object, as to give consent.
   </span>
 </p>
 </div>
 
-A [=person=] providing consent does not imply consent from other [=people=] whose data may be
-included or implicated.
+A [=person=] may share data about other [=people=] (e.g. a picture with both that person and others). If that person consents to the processing of that data, this does not imply that those other people have consented as well.
 
 <div class="practice">
   <p>

--- a/index.html
+++ b/index.html
@@ -1968,8 +1968,8 @@ included or implicated.
 <div class="practice">
   <p>
     <span class="practicelab" id="principle-consent-otherpeople">
-      [=Actors=] should provide accessible functionality to access, correct and remove data about
-      [=people=] to those [=people=] when that data may have been provided by someone else.
+      [=Actors=] should provide functionality to access, correct, and remove data about
+      [=people=] to those [=people=] when that data has been provided by someone else.
     </span>
   </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -1955,13 +1955,29 @@ Examples of alternatives to interrupting users with consent requests include:
 <div class="practice">
 <p>
   <span class="practicelab" id="principle-consent-withdraw">
-    It should be as easy for a user to check what consent they have given,
+  It should be as easy for a [=person=] to check what consent they have given,
 	to withdraw consent, or to opt out or object,
 	as to give consent.
   </span>
 </p>
 </div>
 
+A [=person=] providing consent does not imply consent from other [=people=] whose data may be
+included or implicated.
+
+<div class="practice">
+  <p>
+    <span class="practicelab" id="principle-consent-otherpeople">
+      [=Actors=] should provide accessible functionality to access, correct and remove data about
+      [=people=] to those [=people=] when that data may have been provided by someone else.
+    </span>
+  </p>
+</div>
+
+<div class="note">
+  See <a href="#group-privacy">Group Privacy</a> and <a href="#data-rights">Data Rights</a> for
+  further discussion of privacy of people other than the user.
+</div>
 
 ## Notifications and Interruptions {#interruptions}
 


### PR DESCRIPTION
addresses #24

related to #135

note that consent does not imply consent of people other than the user

add principle to consent section that functionality must be provided to access or remove data in non-user cases


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/287.html" title="Last updated on Jun 30, 2023, 8:15 PM UTC (f4c7d7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/287/5286a4e...f4c7d7e.html" title="Last updated on Jun 30, 2023, 8:15 PM UTC (f4c7d7e)">Diff</a>