### PR TITLE
potential small group privacy examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,6 +766,13 @@ is the fitness app Strava that did not reveal individual behaviour or legal iden
 maps of popular running routes. In doing so, it revealed secret US bases around which military
 personnel took frequent runs ([[?Strava-Debacle]], [[?Strava-Reveal-Military]]).
 
+People's privacy interests may also be affected when information about a small group of people is
+processed, even if no individualized data is exposed. For example, browsing activity of the students
+in a classroom may be sensitive even if their teacher doesn't learn exactly which student accessed a
+particular resource about a health issue. Targeting presentation of information to a small group may
+also be inappropriate: for example, targeting messages to people who visited a particular clinic or
+are empaneled on a particular jury may be invasive even without uniquely individual data.
+
 When [=people=] do not know that they are members of a group, when they cannot easily find other
 members of the group so as to advocate for their rights together, or when they cannot easily
 understand why they are being categorised into a given group, their ability to protect themselves


### PR DESCRIPTION
addresses #251 

This covers both:
* revealing data about a small group of people affects individual privacy even without individualized data (revealing to a teacher that a student in the class looked up a particular health condition)
* targeting messages to a small group of people (showing a message just to people who visited a particular Planned Parenthood clinic, or who are empaneled on a jury)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/289.html" title="Last updated on Jun 27, 2023, 10:14 PM UTC (d53e53c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/289/5286a4e...d53e53c.html" title="Last updated on Jun 27, 2023, 10:14 PM UTC (d53e53c)">Diff</a>