### PR TITLE
change wording around self-governing

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,8 +691,8 @@ the work of ensuring [=data processing=] of which they are the subject or recipi
 Data systems that are based on asking [=people=] for their [=consent=] tend to increase
 [=privacy labour=].
 
-More generally, implementations of [=privacy=] are often dominated by self-governing approaches that
-offload [=labour=] to [=people=]. This is notably true of the regimes descended from the
+More generally, implementations of [=privacy=] are often dominated by approaches that
+offload [=labour=] to [=people=] (self-governing). This is notably true of the regimes descended from the
 <dfn data-lt="FIPs">Fair Information Practices</dfn> ([=FIPs=]), a loose set of principles initially
 elaborated in the 1970s in support of individual [=autonomy=] in the face of growing concerns with databases. The
 [=FIPs=] generally assume that there is sufficiently little [=data processing=] taking place that any


### PR DESCRIPTION
This is pretty minimal. It just re-words the sentence to include the definition first before we mention the term self-governing. Fixes #233.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/291.html" title="Last updated on Jun 28, 2023, 2:25 PM UTC (dc412f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/291/86d1c1f...dc412f9.html" title="Last updated on Jun 28, 2023, 2:25 PM UTC (dc412f9)">Diff</a>