### PR TITLE
Adjust "bp-summary" title in table of contents too

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,9 @@
             prac.classList.remove('advisement');
             prac.classList.add('principle');
           }
-          let h2 = document.querySelector('#bp-summary h2');
-          h2.innerHTML = h2.innerHTML.replace('Best Practices Summary', 'Principles Summary');
+          for (let el of document.querySelectorAll('#bp-summary h2, #toc a[href="#bp-summary"]')) {
+            el.innerHTML = el.innerHTML.replace('Best Practices Summary', 'Principles Summary');
+          }
         }
       ],
       localBiblio: {


### PR DESCRIPTION
Post-processing replaced the title of the `bp-summary` title in the body of the text but not in the table of contents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/privacy-principles/pull/320.html" title="Last updated on Jul 2, 2023, 7:50 AM UTC (51b80f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/320/077d2a9...tidoust:51b80f8.html" title="Last updated on Jul 2, 2023, 7:50 AM UTC (51b80f8)">Diff</a>