### PR TITLE
Copy edit Section 2 intro, fixes #302.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1024,7 +1024,7 @@ the success of advertising campaigns. Even this small amount of information is s
 # Principles for Privacy on the Web
 
 This section describes a set of principles designed to apply to the web
-[=context=] in general. More specific [=contexts=] on the web may need more
+[=context=] in general. Specific [=contexts=] on the web may need more
 constraints or other considerations. In time, we expect to see more specialized
 privacy principles published, for more specific [=contexts=] on the web.
 
@@ -2122,14 +2122,14 @@ are employees with respect to their employers, are facing a steep asymmetry of p
 are people in some situations of intellectual or psychological impairment, are
 refugees, etc.
 
-## Context {#context}
+## Contexts {#context}
 
 A <dfn>context</dfn> is a physical or digital environment in which [=people=] interact with other
 [=actors=], and which the [=people=] understand as distinct from other [=contexts=].
 
 A [=context=] is not defined in terms of who owns or controls it. Sharing
-[=data=] between different [=contexts=] of a single company is just as much
-a [=privacy violation=] as if the same data were shared between unrelated [=actors=].
+[=data=] between different [=contexts=] of a single company is
+a [=privacy violation=], just as if the same data were shared between unrelated [=actors=].
 
 ## Server-Side Actors {#parties}
 

--- a/index.html
+++ b/index.html
@@ -1023,17 +1023,13 @@ the success of advertising campaigns. Even this small amount of information is s
 
 # Principles for Privacy on the Web
 
-As indicated above, different [=contexts=] require different principles. This section describes a set
-of principles designed to apply to the Web [=context=] in general. The Web is a big place, and we
-fully expect more specific [=contexts=] of the Web to add their own principles to further constrain
-[=information flows=].
+This section describes a set of principles designed to apply to the web
+[=context=] in general. More specific [=contexts=] on the web may need more
+constraints or other considerations. In time, we expect to see more specialized
+privacy principles published, for more specific [=contexts=] on the web.
 
-To the extent possible, [=user agents=] are expected to enforce these principles. However, this is not
-always possible and additional enforcement mechanisms are needed. One particularly salient issue
-is that a [=context=] is not defined in terms of who owns or controls it. Sharing
-[=data=] between different [=contexts=] of a single company is just as much a [=privacy violation=] as
-if the same data were shared between unrelated [=actors=].
-
+These principles should be enforced by [=user agents=]. When this is not possible,
+additional enforcement mechanisms are needed.
 
 ## Identity on the Web {#identity}
 
@@ -2126,8 +2122,14 @@ are employees with respect to their employers, are facing a steep asymmetry of p
 are people in some situations of intellectual or psychological impairment, are
 refugees, etc.
 
+## Context {#context}
+
 A <dfn>context</dfn> is a physical or digital environment in which [=people=] interact with other
 [=actors=], and which the [=people=] understand as distinct from other [=contexts=].
+
+A [=context=] is not defined in terms of who owns or controls it. Sharing
+[=data=] between different [=contexts=] of a single company is just as much
+a [=privacy violation=] as if the same data were shared between unrelated [=actors=].
 
 ## Server-Side Actors {#parties}
 


### PR DESCRIPTION
Moves extra text about context to a Context section in the Common Concepts appendix.

See https://github.com/w3ctag/privacy-principles/pull/321 for edits in context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/322.html" title="Last updated on Jul 5, 2023, 4:15 PM UTC (a26e28a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/322/077d2a9...a26e28a.html" title="Last updated on Jul 5, 2023, 4:15 PM UTC (a26e28a)">Diff</a>