### PR TITLE
Harrasment, for #310 and #311

### DIFF
--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,7 @@ appropriately.
 Link this to [[[#guardians]]].
 </aside>
 
-## Abuse
+## Protecting users from abusive behaviour
 
 <div class="practice">
   <p>
@@ -1763,7 +1763,7 @@ exacerbated by other violations of privacy.
 Harassment may include: sending [=unwanted information=]; directing others to contact
 or bother a person ("dogpiling"); disclosing [sensitive information](#sensitive-information) about a person; posting false information about a person; impersonating a person; insults; threats; and hateful or demeaning speech.
 
-Disclosure of identifying or contact information (including "doxxing") can be used to send often persistent [=unwanted information=] that amounts to harassment.
+Disclosure of identifying or contact information (including "doxxing") can often be used to cause additional attackers to send persistent [=unwanted information=] that amounts to harassment.
 Disclosure of location information can be used to intrude on a
 person's physical safety or space.
 
@@ -1773,11 +1773,11 @@ hosts or intermediaries are supportive of or complicit in the abuse.
 Effective reporting is likely to require:
 
 * standardized mechanisms to identify abuse reporting contacts;
-* visible, usable ways provided by sites and user agents to report abuse;
+* sites and user agents to provide visible and usable ways to report abuse;
 * identifiers to refer to senders and content;
 * the ability to provide context and explanation of harms;
 * people responsible for promptly responding to reports;
-* tools for pooling mitigation information (see [[[#example-10]]]).
+* tools for pooling mitigation information (see [[[#example-reducing-unwanted-information]]]).
 
 <aside class="note">
   Some useful research overviews of online harassment include: [[?PEW-Harassment]],
@@ -1788,13 +1788,14 @@ Effective reporting is likely to require:
 that are typically harmless individually but that become a nuisance in aggregate (spam) to the
 sending of explicit, graphic, or violent images.
 
-<aside class="example">
 System designers should take steps to make the sending of unwanted information more difficult
 or more costly, and to make the senders more accountable.
 
+
+<aside class="example" id="example-reducing-unwanted-information">
 Examples of mitigations include:
 
-* Restricting what new users of a service can post, e.g. limiting links and media until they have
+* Restricting what new users of a service can post, e.g. limiting links and media until a user has
   interacted a sufficient number of times over a given period with a larger group. This helps to
   raise the cost of producing [sock puppet accounts](https://en.wikipedia.org/wiki/Sock_puppet_account) and gives new users time to understand local norms before posting.
 * Only accepting communication between [=people=] who have an established relationship of some kind,

--- a/index.html
+++ b/index.html
@@ -1744,7 +1744,14 @@ Link this to [[[#guardians]]].
   <p>
     <span class="practicelab" id="abuse-reporting">
       Systems that allow for communicating on the Web must provide an
-      effective capability to report abuse. [=User agents=] and [=sites=] must
+      effective capability to report abuse. 
+        </span>
+  </p>
+</div>
+<div class="practice">
+  <p>
+    <span class="practicelab" id="abuse-protection">
+      [=User agents=] and [=sites=] must
       take steps to protect their users from abusive behaviour, and abuse
       mitigation must be considered when designing web platform features.
     </span>
@@ -1768,7 +1775,7 @@ Disclosure of location information can be used to intrude on a
 person's physical safety or space.
 
 Reporting mechanisms are mitigations, but may not prevent harassment, particularly in cases where
-hosts or intermediaries are supportive of or complicit in the abuse.
+hosts, moderators, or other intermediaries are supportive of or complicit in the abuse.
 
 Effective reporting is likely to require:
 

--- a/index.html
+++ b/index.html
@@ -1740,34 +1740,6 @@ Link this to [[[#guardians]]].
 
 ## Harassment
 
-Online <dfn>harassment</dfn> is the "pervasive or severe targeting of an individual or group online
-through harmful behavior" [[PEN-Harassment]]. Harassment is a prevalent problem on the Web,
-particularly via social media. While harassment may affect any person using the Web, it may be more
-severe and its consequences more impactful for LGBTQ people, women, people in racial or ethnic
-minorities, people with disabilities, [=vulnerable people=] and other marginalized groups.
-
-<aside class="note">
-  Some useful research overviews of online harassment include: [[?PEW-Harassment]],
-  [[?Addressing-Cyber-Harassment]] and [[?Internet-of-Garbage]].
-</aside>
-
-[=Harassment=] is both a violation of privacy itself and can be magnified or facilitated by other
-violations of privacy.
-
-Abusive online behavior may include: sending [=unwanted information=]; directing others to contact
-or bother a person ("dogpiling"); disclosing sensitive information about a person; posting false
-information about a person; impersonating a person; insults; threats; and hateful or demeaning
-speech.
-
-Disclosure of identifying or contact information (including "doxxing") can be used, including by
-additional attackers, to send often persistent unwanted information that amounts to harassment.
-Disclosure of location information can be used, including by additional attackers, to intrude on a
-person's physical safety or space.
-
-Mitigations for harassment include but extend beyond mitigations for unwanted information and other
-privacy principles. Harassment can include harmful activity with a wider distribution than just the
-target of harassment.
-
 <div class="practice">
   <p>
     <span class="practicelab" id="abuse-reporting">
@@ -1777,19 +1749,38 @@ target of harassment.
   </p>
 </div>
 
+Online <dfn>harassment</dfn> is the "pervasive or severe targeting of an individual or group online
+through harmful behavior" [[PEN-Harassment]]. Harassment is a prevalent problem on the web,
+particularly via social media. While harassment may affect any person using the web, it may be more
+severe and its consequences more impactful for LGBTQ people, women, people in racial or ethnic
+minorities, people with disabilities, [=vulnerable people=] and other marginalized groups.
+
+[=Harassment=] is both a violation of privacy itself and can be enabled or
+exacerbated by other violations of privacy.
+
+Harassment may include: sending [=unwanted information=]; directing others to contact
+or bother a person ("dogpiling"); disclosing [sensitive information](#sensitive-information) about a person; posting false information about a person; impersonating a person; insults; threats; and hateful or demeaning speech.
+
+Disclosure of identifying or contact information (including "doxxing") can be used to send often persistent [unwanted information](#unwanted-information) that amounts to harassment.
+Disclosure of location information can be used to intrude on a
+person's physical safety or space.
+
 Reporting mechanisms are mitigations, but may not prevent harassment, particularly in cases where
 hosts or intermediaries are supportive of or complicit in the abuse.
 
-<div class="note">
-  Effective reporting is likely to require:
+Effective reporting is likely to require:
 
-  * standardized mechanisms to identify abuse reporting contacts
-  * visible, usable ways provided by sites and user agents to report abuse
-  * identifiers to refer to senders and content
-  * the ability to provide context and explanation of harms
-  * people responsible for promptly responding to reports
-  * tools for pooling mitigation information (see Unwanted information, below)
-</div>
+* standardized mechanisms to identify abuse reporting contacts;
+* visible, usable ways provided by sites and user agents to report abuse;
+* identifiers to refer to senders and content;
+* the ability to provide context and explanation of harms;
+* people responsible for promptly responding to reports;
+* tools for pooling mitigation information (see [[[#unwanted-information]]]).
+
+<aside class="note">
+  Some useful research overviews of online harassment include: [[?PEW-Harassment]],
+  [[?Addressing-Cyber-Harassment]] and [[?Internet-of-Garbage]].
+</aside>
 
 ## Unwanted Information {#unwanted-information}
 

--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,7 @@ appropriately.
 Link this to [[[#guardians]]].
 </aside>
 
-## Harassment
+## Abuse
 
 <div class="practice">
   <p>

--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,7 @@ appropriately.
 Link this to [[[#guardians]]].
 </aside>
 
-## Protecting users from abusive behaviour
+## Protecting web users from abusive behaviour
 
 <div class="practice">
   <p>

--- a/index.html
+++ b/index.html
@@ -1743,8 +1743,10 @@ Link this to [[[#guardians]]].
 <div class="practice">
   <p>
     <span class="practicelab" id="abuse-reporting">
-      Systems that allow for communicating on the Web must provide an effective capability to report
-      abuse.
+      Systems that allow for communicating on the Web must provide an
+      effective capability to report abuse. [=User agents=] and [=sites=] must
+      take steps to protect their users from abusive behaviour, and abuse
+      mitigation must be considered when designing web platform features.
     </span>
   </p>
 </div>
@@ -1761,7 +1763,7 @@ exacerbated by other violations of privacy.
 Harassment may include: sending [=unwanted information=]; directing others to contact
 or bother a person ("dogpiling"); disclosing [sensitive information](#sensitive-information) about a person; posting false information about a person; impersonating a person; insults; threats; and hateful or demeaning speech.
 
-Disclosure of identifying or contact information (including "doxxing") can be used to send often persistent [unwanted information](#unwanted-information) that amounts to harassment.
+Disclosure of identifying or contact information (including "doxxing") can be used to send often persistent [=unwanted information=] that amounts to harassment.
 Disclosure of location information can be used to intrude on a
 person's physical safety or space.
 
@@ -1775,42 +1777,26 @@ Effective reporting is likely to require:
 * identifiers to refer to senders and content;
 * the ability to provide context and explanation of harms;
 * people responsible for promptly responding to reports;
-* tools for pooling mitigation information (see [[[#unwanted-information]]]).
+* tools for pooling mitigation information (see [[[#example-10]]]).
 
 <aside class="note">
   Some useful research overviews of online harassment include: [[?PEW-Harassment]],
   [[?Addressing-Cyber-Harassment]] and [[?Internet-of-Garbage]].
 </aside>
 
-## Unwanted Information {#unwanted-information}
-
-Receiving unsolicited information that either may cause distress or waste the recipient's
-time or resources is a violation of privacy.
-
-<div class="practice">
-
-<p>
-  <span class="practicelab" id="principle-protect-unwanted-information">
-    [=User agents=] and other [=actors=] should take
-    steps to ensure that their [=user=] is not exposed to unwanted information. Technical standards
-    must consider the delivery of unwanted information as part of their architecture and must
-    mitigate it accordingly.
-  </span>
-</p>
-</div>
-
 <dfn>Unwanted information</dfn> covers a broad range of unsolicited communication, from messages
 that are typically harmless individually but that become a nuisance in aggregate (spam) to the
-sending of images that will cause shock or disgust due to their graphic, violent, or explicit nature
-(e.g. pictures of one's genitals). While it is impossible, in a communication system involving many
-[=people=], to offer perfect protection against all kinds of unwanted information, steps can be
-taken to make the sending of such messages more difficult or more costly, and to make the senders
-more accountable. Examples of mitigations include:
+sending of explicit, graphic, or violent images.
 
-* Restricting what new users of a service can post, notably limiting links and media until they have
+<aside class="example">
+System designers should take steps to make the sending of unwanted information more difficult
+or more costly, and to make the senders more accountable.
+
+Examples of mitigations include:
+
+* Restricting what new users of a service can post, e.g. limiting links and media until they have
   interacted a sufficient number of times over a given period with a larger group. This helps to
-  raise the cost of producing sockpuppet accounts and gives new users the occasion to understand
-  local norms before posting.
+  raise the cost of producing [sock puppet accounts](https://en.wikipedia.org/wiki/Sock_puppet_account) and gives new users time to understand local norms before posting.
 * Only accepting communication between [=people=] who have an established relationship of some kind,
   such as being part of a shared group. Protocols should consider requiring a handshake between
   [=people=] prior to enabling communication.
@@ -1819,10 +1805,9 @@ more accountable. Examples of mitigations include:
 * Supporting the ability for [=people=] to block another [=actor=] such that they cannot send information
   again.
 * Pooling mitigation information, for instance shared block lists, shared spam-detection
-  information, or public information about misbehaving [=actors=]. As always, the collection and
-  sharing of [=information=] for safety purposes should be limited and placed under collective
-  governance.
-
+  information, or public information about misbehaving [=actors=].
+* Enabling users to filter out or hide information or media based on tags or content warnings.
+</aside>
 
 ## Vulnerability {#vulnerability}
 


### PR DESCRIPTION
Unwanted Information and Harassment seemed to be saying a lot of the same things. I've merged the principles, but retained the definitions. Renamed the section to "Abuse". I feel it shortens and simplifies things, but interested to hear what others think. Let me know if I lost anything. 

See https://github.com/w3ctag/privacy-principles/pull/321 for edits in context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#abuse
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/328.html#abuse" title="Last updated on Aug 23, 2023, 4:16 PM UTC (b10c5cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/328/077d2a9...b10c5cd.html" title="Last updated on Aug 23, 2023, 4:16 PM UTC (b10c5cd)">Diff</a>