### PR TITLE
Cite RFC6772

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,8 +1327,11 @@ also can be an indicator of belonging to an ethnic minority. Precise location
 information can be extremely sensitive (because it's identifying, because it
 allows for in-person intrusions, because it can reveal detailed information
 about a person's life) but it might also be public and not sensitive at all, or
-it might be low-enough granularity that it is much less sensitive for many
-people.
+it might be low-enough granularity that it is less sensitive for many
+people. Reducing granularity of location information may not hide precise location information from
+an [=actor=], however, particularly if location information is repeatedly requested over time or if
+the [=actor=] has other relevant information about the [=person=] [<a
+data-cite="RFC6772#section-13.5">RFC6772</a>].
 
 When considering whether a class of information is likely to be sensitive to
 a person, consider at least these factors:

--- a/index.html
+++ b/index.html
@@ -1328,7 +1328,7 @@ information can be extremely sensitive (because it's identifying, because it
 allows for in-person intrusions, because it can reveal detailed information
 about a person's life) but it might also be public and not sensitive at all, or
 it might be low-enough granularity that it is less sensitive for many
-people. Beware that reducing granularity of location information may not hide precise location information from
+people. Beware that reducing granularity of location information might not hide precise location information from
 an [=actor=], particularly if location information is repeatedly requested over time or if
 the [=actor=] has other relevant information about the [=person=] [<a
 data-cite="RFC6772#section-13.5">RFC6772</a>].

--- a/index.html
+++ b/index.html
@@ -1328,8 +1328,8 @@ information can be extremely sensitive (because it's identifying, because it
 allows for in-person intrusions, because it can reveal detailed information
 about a person's life) but it might also be public and not sensitive at all, or
 it might be low-enough granularity that it is less sensitive for many
-people. Reducing granularity of location information may not hide precise location information from
-an [=actor=], however, particularly if location information is repeatedly requested over time or if
+people. Beware that reducing granularity of location information may not hide precise location information from
+an [=actor=], particularly if location information is repeatedly requested over time or if
 the [=actor=] has other relevant information about the [=person=] [<a
 data-cite="RFC6772#section-13.5">RFC6772</a>].
 


### PR DESCRIPTION
noting that low-granularity information can still reveal precise information
and some of the conditions for why
less emphatic about the sensitivity difference

fixes #281 (intended to, anyway)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/339.html" title="Last updated on Aug 1, 2023, 6:17 PM UTC (8f7ddf5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/339/33d5090...8f7ddf5.html" title="Last updated on Aug 1, 2023, 6:17 PM UTC (8f7ddf5)">Diff</a>