### PR TITLE
Separate device administrators from UA administrators.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@ Computing devices have <dfn data-lt="administrator">administrators</dfn>, who
 have privileged access to the devices in order to install and configure the
 programs that run on them. The <dfn data-lt="device owner">owner</dfn> of a
 device often authorizes the [=administrators=], but there are also ways to get
-administrator access without the [=device owner's=] knowledge. Some [=user
+administrator access without the [=device owner=]'s knowledge. Some [=user
 agents=] can also assign an [=administrator=] based on the account that's logged
 into the [=user agent=].
 

--- a/index.html
+++ b/index.html
@@ -1616,22 +1616,24 @@ for example using the <a data-cite="IAD#">Institutional Analysis and Development
 
 <div class="practice" data-audiences="user-agents">
 <span class="practicelab" id="principle-owned-devices-disclose-surveillance">
-[=User agents=] must not help a device [=administrator=] surveil the people
-using the devices they administrate without those people's knowledge. [=User
-agents=] should not tell a device [=administrator=] about user behavior except
+[=User agents=] must not help an [=administrator=] surveil the people
+using the devices or software they administer without those people's knowledge.
+[=User agents=] should not tell an [=administrator=] about user behavior except
 when that disclosure is necessary to enforce reasonable constraints on use of
-the device.
+the device or software.
 </span>
 </div>
 <div class="note">
 See [[[#guardians]]] for more detail on how this principle applies to vulnerable people with [=guardians=].
 </div>
 
-Computing devices have <dfn data-lt="device owner">owners</dfn>, who have
-<dfn>administrator</dfn> access to the devices in order to install and
-configure the programs that run on them. As a program running on a device,
-a [=user agent=] generally can't tell whether the [=administrator=] who has
-installed and configured it was authorized by the device's actual owner.
+Computing devices have <dfn data-lt="administrator">administrators</dfn>, who
+have privileged access to the devices in order to install and configure the
+programs that run on them. The <dfn data-lt="device owner">owner</dfn> of a
+device often authorizes the [=administrators=], but there are also ways to get
+administrator access without the [=device owner's=] knowledge. Some [=user
+agents=] can also assign an [=administrator=] based on the account that's logged
+into the [=user agent=].
 
 Sometimes the [=person=] using a device doesn't own the device or have
 [=administrator=] access to it (e.g. an employer providing a device to an

--- a/index.html
+++ b/index.html
@@ -1616,11 +1616,11 @@ for example using the <a data-cite="IAD#">Institutional Analysis and Development
 
 <div class="practice" data-audiences="user-agents">
 <span class="practicelab" id="principle-owned-devices-disclose-surveillance">
-[=User agents=] must not help an [=administrator=] surveil the people
-using the devices or software they administer without those people's knowledge.
 [=User agents=] should not tell an [=administrator=] about user behavior except
 when that disclosure is necessary to enforce reasonable constraints on use of
 the device or software.
+Even when a disclosure is reasonable, [=user agents=] must ensure their users
+know about this surveillance.
 </span>
 </div>
 <div class="note">

--- a/index.html
+++ b/index.html
@@ -1630,10 +1630,9 @@ See [[[#guardians]]] for more detail on how this principle applies to vulnerable
 Computing devices have <dfn data-lt="administrator">administrators</dfn>, who
 have privileged access to the devices in order to install and configure the
 programs that run on them. The <dfn data-lt="device owner">owner</dfn> of a
-device often authorizes the [=administrators=], but there are also ways to get
-administrator access without the [=device owner=]'s knowledge. Some [=user
-agents=] can also assign an [=administrator=] based on the account that's logged
-into the [=user agent=].
+device can authorize an [=administrator=] to administer the whole device.
+Some [=user agent=] [=implementations=] can also assign an [=administrator=] to
+manage a particular [=user agent=] based on the account that's logged into it.
 
 Sometimes the [=person=] using a device doesn't own the device or have
 [=administrator=] access to it (e.g. an employer providing a device to an


### PR DESCRIPTION
Mostly this consisted of using "administrator" instead of "device
administrator", and I added a sentence saying that UAs sometimes assign
an administrator based on the user's account.

Fixes #353. @reillyeon, how does this look?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#device-administrators
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/368.html#device-administrators" title="Last updated on Nov 15, 2023, 5:15 PM UTC (0dafa68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/368/7dd3a4f...jyasskin:0dafa68.html" title="Last updated on Nov 15, 2023, 5:15 PM UTC (0dafa68)">Diff</a>