### PR TITLE
Make the minimization text more precise, and merge in the UA principle.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,18 +1178,12 @@ according to their [=users=]' wishes.
 ## Data Minimization {#data-minimization}
 
 <div class="practice" data-audiences="websites user-agents"><span class="practicelab">[=Sites=], [=user agents=], and other [=actors=]
-should minimize the amount of [=personal data=] they transfer.</span></div>
+should restrict the [=personal data=] they transfer to what's necessary to achieve their users'
+goals and interests.</span></div>
 
 <div class="practice" data-audiences="api-designers"><span class="practicelab">Web APIs should be designed to minimize the amount of data that sites need
 to request to carry out their users' goals and provide granularity and user controls over <a>personal
 data</a> that is communicated to sites.</span></div>
-
-<div class="practice" data-audiences="user-agents">
-<span class="practicelab">In maintaining duties of [=duty of
-protection|protection=], [=duty of discretion|discretion=] and [=duty of loyalty|loyalty=], user agents should share data only when it either is needed
-to satisfy a user's immediate goals or aligns with the user's wishes and
-interests.</span>
-</div>
 
 Data minimization limits the risks of data being disclosed or misused. It also
 helps [=user agents=] and other [=actors=] more meaningfully explain the decisions their users need


### PR DESCRIPTION
I'm not certain this is the right change. I'll explain how I got here so the rest of the task force can suggest a better improvement.

I was trying to explain what "minimize" meant in the first principle. Someone who's not already familiar with "data minimization" wouldn't know how much to minimize data or when it's ok to stop. The definition at https://edps.europa.eu/data-protection/data-protection/glossary/d_en says to "limit the collection of personal information to what is directly relevant and necessary to accomplish a specified purpose.", so I could just use "specified purpose" in this text, but that purpose could be spying on users, so I think it's not what the task force has in mind. "necessary to achieve their users' goals and interests" matches the direction we've gone in the rest of the document. There might be good reasons for sites to break this rule sometimes, but that's why it's a "should".

Once we have that, the third principle says almost the same thing as the first, so it seems mergeable. We lose the "in maintaining duties of protection, discretion, and loyalty" part, but this is the [only principle](https://w3ctag.github.io/privacy-principles/#bp-summary) with that sort of introduction, and nothing here makes https://w3ctag.github.io/privacy-principles/#user-agents less applicable. I've also lost some precision, but I'm happy to take suggestions for what to add back to the general principle.