### PR TITLE
Avoid implying that ancillary APIs w/ new information should default to enabled.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1340,8 +1340,9 @@ the person's permission.
 
 <div class="practice" data-audiences="user-agents">
 <span class="practicelab" id="principle-disabling-ancillary-apis-with-new-information">
-User agents should provide a way to disable [=ancillary APIs that provide new
-information=].
+User agents should provide a way to enable or disable [=ancillary APIs that
+provide new information=] and should set the default according to their users'
+needs.
 </span>
 </div>
 


### PR DESCRIPTION
Fixes #372.

I considered reversing the order, to start with "should follow their users' needs in deciding the default enabledness [ew] of ancillary ...", but I think the key in this principle is that users should be able to change it more easily than by switching browsers.

[Also, it's kind of amazing that we don't have a better word for the question of whether something is enabled or disabled. https://english.stackexchange.com/q/92781/122144, https://english.stackexchange.com/q/102995/122144, and https://stackoverflow.com/q/2544435/943619 don't have options I like.]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/385.html" title="Last updated on Dec 4, 2023, 6:15 PM UTC (2028122)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/385/c2806a2...jyasskin:2028122.html" title="Last updated on Dec 4, 2023, 6:15 PM UTC (2028122)">Diff</a>