### PR TITLE
Vulnerable people wording and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,10 +787,10 @@ and choice</i>", which, in today's digital environment, is often an indication t
 ## Vulnerability {#vulnerability}
 
 Sometimes particular groups of people, such as children, or the elderly,
-are classed as “vulnerable.” However, any [=person=] could be vulnerable in
+are classed as [=vulnerable people=]. However, any [=person=] could be vulnerable in
 one or more contexts, sometimes without realizing it.
 A [=person=] may not realise when they disclose personal data that
-they are vulnerable or could become vulnerable, and a [=party=] may have
+they are vulnerable or could become vulnerable, and an [=actor=] may have
 no way of knowing that a person is vulnerable.
 
 Some individuals may be more vulnerable to privacy risks or harm as a result of
@@ -2119,8 +2119,8 @@ be treated with greater default privacy protections and may be considered unable
 People can be vulnerable for different reasons, and some people may
 be vulnerable in a specific [=context=]. For example, a child might
 be vulnerable in many contexts, but a person in a position of power imbalance
-with an employer or other [=party=] might be specifically vulnerable in a
-context where they must interact with that party.  See [[[#vulnerability]]].
+with an employer or other [=actor=] might be vulnerable in the contexts
+where that actor is also present.  See [[[#vulnerability]]].
 
 ## Contexts {#context}
 
@@ -2270,7 +2270,7 @@ cross-context recognition.
 Systems which [=recognize=] people across [=contexts=] need
 to be careful not to apply the principles of one [=context=] in ways that
 violate the principles around use of information acquired in a different
-[=context=]. This is particularly true for [=vulnerable=] people, as
+[=context=]. This is particularly true for [=vulnerable people=], as
 recognising them in different [=contexts=] may force traits into the open
 that reveal their vulnerability. For example, if you meet your therapist at a
 party, you expect them to have different discussion topics with you than they

--- a/index.html
+++ b/index.html
@@ -2116,10 +2116,11 @@ is a [=person=] whose ability to make their own choices can be taken away more
 easily than usual. Among other things, they should
 be treated with greater default privacy protections and may be considered unable to
 [=consent=] to various interactions with a system.
-People can be vulnerable for different reasons, for example because they are children,
-are employees with respect to their employers, are facing a steep asymmetry of power,
-are people in some situations of intellectual or psychological impairment, are
-refugees, etc. See [[[#vulnerability]]].
+People can be vulnerable for different reasons, and some people may
+be vulnerable in a specific [=context=]. For example, a child might
+be vulnerable in many contexts, but a person in a position of power imbalance
+with an employer or other [=party=] might be specifically vulnerable in a
+context where they must interact with that party.  See [[[#vulnerability]]].
 
 ## Contexts {#context}
 

--- a/index.html
+++ b/index.html
@@ -786,10 +786,12 @@ and choice</i>", which, in today's digital environment, is often an indication t
 
 ## Vulnerability {#vulnerability}
 
-Sometimes particular groups are classed as “vulnerable” (e.g. children, or the
-elderly), but anyone could become privacy vulnerable in a given context.
+Sometimes particular groups of people, such as children, or the elderly,
+are classed as “vulnerable.” However, any [=person=] could be vulnerable in
+one or more contexts, sometimes without realizing it.
 A [=person=] may not realise when they disclose personal data that
-they are vulnerable or could become vulnerable.
+they are vulnerable or could become vulnerable, and a [=party=] may have
+no way of knowing that a person is vulnerable.
 
 Some individuals may be more vulnerable to privacy risks or harm as a result of
 collection, misuse, loss or theft of personal data because:

--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@ and choice</i>", which, in today's digital environment, is often an indication t
 ## Vulnerability {#vulnerability}
 
 Sometimes particular groups of people, such as children, or the elderly,
-are classed as [=vulnerable people=]. However, any [=person=] could be vulnerable in
+are classified as [=vulnerable people=]. However, any [=person=] could be vulnerable in
 one or more contexts, sometimes without realizing it.
 A [=person=] may not realise when they disclose personal data that
 they are vulnerable or could become vulnerable, and an [=actor=] may have


### PR DESCRIPTION
This addresses #373 -- adds some wording on vulnerable people who don't know it, and context by context vulnerability, and some links between "vulnerability" and "vulnerable people."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/pull/402.html" title="Last updated on Feb 14, 2024, 5:24 PM UTC (9849885)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/402/2ddef7f...9849885.html" title="Last updated on Feb 14, 2024, 5:24 PM UTC (9849885)">Diff</a>