### PR TITLE
Grammar fixes including fixing missing oxford comas.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1046,7 +1046,7 @@ off between principles.
 
 Once one is choosing between different designs at the Pareto frontier, the choice of which
 privacy principles to prefer is complex and depends heavily on the details of each
-particular situation. Note that peoples' privacy can also be in tension
+particular situation. Note that people's privacy can also be in tension
 with non-privacy concerns. As discussed in the [[[Ethical-Web]]], "it is important to
 consider the context in which a particular technology is being applied, the expected
 audience(s) for the technology, who the technology benefits and who it may disadvantage,
@@ -1063,7 +1063,7 @@ for other purposes, like to grow the service.</span></p>
 This is a special case of the <a href="#no-secondary-use">more general principle that data should not be used for more
 purposes than those specified when the data was collected</a>.
 
-Services sometimes use peoples' data in order to protect those or other people.
+Services sometimes use people's data in order to protect those or other people.
 A service that does this should explain what data it's
 using for this purpose. It should also say how it might use or share a person's
 data if it believes that person has violated the service's rules.

--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ need of protection.
 
 <dfn data-lt="governance">Data governance</dfn> is the system of principles that regulate [=information flows=].
 [=Data governance=] determines how
-which [=actors=] can collect what [=data=] and how they may, must, or must not [=process=] it
+ [=actors=] can collect what [=data=] and how they may, must, or must not [=process=] it
 ([[?GKC-Privacy]], [[?IAD]]). This document provides building blocks for [=data governance=]
 that puts [=people=] first.
 
@@ -663,7 +663,7 @@ On the web, [=information flows=] may involve a wide variety of [=actors=] that 
 recognizable or obvious to a user within a particular interaction. Visiting a website may involve
 the actors that contribute to operating that site, but also actors with network access,
 which may include: Internet service providers; other network operators; local institutions providing
-a network connection including schools, libraries or universities; government intelligence services;
+a network connection including schools, libraries, or universities; government intelligence services;
 malicious hackers who have gained access to the network or the systems of any of the other actors.
 High-level threats including [=surveillance=] may be pursued by these actors. Pervasive monitoring,
 a form of large-scale, indiscriminate surveillance, is a known attack on the privacy of users of the
@@ -793,9 +793,9 @@ they are vulnerable or could become vulnerable, and an [=actor=] may have
 no way of knowing that a person is vulnerable.
 
 Some individuals may be more vulnerable to privacy risks or harm as a result of
-collection, misuse, loss or theft of personal data because:
+collection, misuse, loss, or theft of personal data because:
 
-* of their attributes, interests, opinions or behaviour;
+* of their attributes, interests, opinions, or behaviour;
 * of the situation or setting (e.g. where there is information asymmetry or other
 power imbalances);
 * they lack the capacity to fully assess the risks;
@@ -807,12 +807,12 @@ product or service.
 
 Additional privacy protections may be needed for personal data of vulnerable
 people or [sensitive information](#hl-sensitive-information) which could cause
-someone to become vulnerable if their personal data is collected, used or
-shared (e.g. blocking tracking elements, sensor data or information about
+someone to become vulnerable if their personal data is collected, used, or
+shared (e.g. blocking tracking elements, sensor data, or information about
 installed software or connected devices).
 
 While sometimes others can help vulnerable people assess privacy risks and
-make decisions about privacy (such as parents, [=guardians=] and peers), everyone
+make decisions about privacy (such as parents, [=guardians=], and peers), everyone
 has their own right to privacy.
 
 ### Guardians {#guardians}
@@ -929,7 +929,7 @@ may publish a picture of an event in which they are featured alongside others wh
 captured in the same picture would prefer their participation not to be disclosed. Another example
 of such issues are sites that enable people to upload their contacts: the person performing the
 upload might be more open to disclosing their social networks than the people they are connected to
-are. Such issues do not necessarily admit simple, straightforward solutions but they need to be
+are. Such issues do not necessarily admit simple, straightforward solutions, but they need to be
 carefully considered by people building websites.
 
 ### Transparency and Research {#transparency-for-research}
@@ -1046,7 +1046,7 @@ off between principles.
 
 Once one is choosing between different designs at the Pareto frontier, the choice of which
 privacy principles to prefer is complex and depends heavily on the details of each
-particular situation. Note that people's privacy can also be in tension
+particular situation. Note that peoples' privacy can also be in tension
 with non-privacy concerns. As discussed in the [[[Ethical-Web]]], "it is important to
 consider the context in which a particular technology is being applied, the expected
 audience(s) for the technology, who the technology benefits and who it may disadvantage,
@@ -1063,7 +1063,7 @@ for other purposes, like to grow the service.</span></p>
 This is a special case of the <a href="#no-secondary-use">more general principle that data should not be used for more
 purposes than those specified when the data was collected</a>.
 
-Services sometimes use people's data in order to protect those or other people.
+Services sometimes use peoples' data in order to protect those or other people.
 A service that does this should explain what data it's
 using for this purpose. It should also say how it might use or share a person's
 data if it believes that person has violated the service's rules.

--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ need of protection.
 
 <dfn data-lt="governance">Data governance</dfn> is the system of principles that regulate [=information flows=].
 [=Data governance=] determines how
- [=actors=] can collect what [=data=] and how they may, must, or must not [=process=] it
+which [=actors=] can collect what [=data=] and how they may, must, or must not [=process=] it
 ([[?GKC-Privacy]], [[?IAD]]). This document provides building blocks for [=data governance=]
 that puts [=people=] first.
 


### PR DESCRIPTION
Several grammar fixes including missing Oxford commas (Oxford comas are used throughout but there are few that were missed), correction of the use of the plural of people, and removal of an extraneous "how".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rinchen/privacy-principles/pull/408.html" title="Last updated on Feb 28, 2024, 5:23 PM UTC (9d494f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/408/064c571...rinchen:9d494f6.html" title="Last updated on Feb 28, 2024, 5:23 PM UTC (9d494f6)">Diff</a>