### PR TITLE
Auto-update our GH Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# See the documentation at
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  # Update actions used by .github/workflows in this repository.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-org: # Groups all Github-authored actions into a single PR.
+        patterns: ["actions/*"]


### PR DESCRIPTION
Since https://github.com/w3ctag/privacy-principles/actions/runs/8084746976 says our actions are out of date.

Editorial, but it'll cause dependabot to open PRs, so I didn't want to do it completely unilaterally.