### PR TITLE
labour -> labor per W3C manual of style US spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,7 +769,7 @@ shows that they make it hard for [=people=] to exercise their rights.
 
 ### Privacy Labor {#privacy-labor}
 
-<dfn data-lt="privacy labor|labor|labor">Privacy labor</dfn> is the practice of having a [=person=] do
+<dfn data-lt="labor">Privacy labor</dfn> is the practice of having a [=person=] do
 the work of ensuring [=data processing=] of which they are the subject or recipient is
 [=appropriate=], instead of putting the responsibility on the [=actors=] who are doing the processing.
 Data systems that are based on asking [=people=] for their [=consent=] tend to increase

--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@ that decrease this number of [=purposes=] or the amount of [=data=] being [=proc
 
 When deployed thoughtfully, these mechanisms can improve [=people=]'s [=autonomy=]. Often,
 however, they are used as a way to avoid putting in the difficult work of deciding which
-types of [=processing=] are [=appropriate=] and which are not, offloading [=privacy labour=]
+types of [=processing=] are [=appropriate=] and which are not, offloading [=privacy labor=]
 to the people using a system.
 
 [=People=] should be able to [=consent=] to data sharing that would
@@ -767,21 +767,21 @@ bad actors, it creates one central point of failure, it is hard to meaningfully 
 for the scale of processing implied by web systems), and experience with existing systems
 shows that they make it hard for [=people=] to exercise their rights.
 
-### Privacy Labour {#privacy-labour}
+### Privacy Labor {#privacy-labor}
 
-<dfn data-lt="privacy labor|labour|labor">Privacy labour</dfn> is the practice of having a [=person=] do
+<dfn data-lt="privacy labor|labor|labor">Privacy labor</dfn> is the practice of having a [=person=] do
 the work of ensuring [=data processing=] of which they are the subject or recipient is
 [=appropriate=], instead of putting the responsibility on the [=actors=] who are doing the processing.
 Data systems that are based on asking [=people=] for their [=consent=] tend to increase
-[=privacy labour=].
+[=privacy labor=].
 
-More generally, implementations of [=privacy=] often offload [=labour=] to [=people=]. This is
+More generally, implementations of [=privacy=] often offload [=labor=] to [=people=]. This is
 notably true of the regimes descended from the <dfn data-lt="FIPs">Fair Information Practices</dfn>
 ([=FIPs=]), a loose set of principles initially elaborated in the 1970s in support of individual
 [=autonomy=] in the face of growing concerns with databases. The [=FIPs=] generally assume that
 there is sufficiently little [=data processing=] taking place that any [=person=] will be able to
 carry out sufficient diligence to be [=autonomous=] in their decision-making. Since they offload
-the [=privacy labour=] to people and assume perfect, unlimited [=autonomy=], the [=FIPs=] do not
+the [=privacy labor=] to people and assume perfect, unlimited [=autonomy=], the [=FIPs=] do not
 forbid specific types of [=data processing=] but only place them under different procedural
 requirements. This approach is no longer [=appropriate=].
 
@@ -1703,7 +1703,7 @@ Different forms of collective decision-making are legitimate depending on what d
 These forms might be governmental bodies at various administrative levels, standards
 organisations, worker bargaining units, or civil society fora.
 Even though collective decision-making can be better than offloading
-[=privacy labour=] to [=individuals=], it is not a panacea.
+[=privacy labor=] to [=individuals=], it is not a panacea.
 Decision-making bodies need to be designed carefully,
 for example using the <a data-cite="IAD#">Institutional Analysis and Development framework</a>.
 
@@ -1935,7 +1935,7 @@ important mitigation for <a>browser fingerprinting</a>.
 </div>
 
 Attempts to obtain consent to [=processing=] that is not in accordance with the person's
-true preferences result in imposing unwanted [=privacy labour=] on the person, and may
+true preferences result in imposing unwanted [=privacy labor=] on the person, and may
 result in people erroneously giving consent that they regret later.
 
 An [=actor=] should not prompt a [=person=] for consent if the


### PR DESCRIPTION
Use US spelling of "labor" instead of "labour', per the W3C Manual of Style: https://www.w3.org/Guide/manual-of-style/#Spelling


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tantek/privacy-principles/pull/429.html" title="Last updated on Sep 11, 2024, 10:04 PM UTC (8b20b2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/429/0889270...tantek:8b20b2b.html" title="Last updated on Sep 11, 2024, 10:04 PM UTC (8b20b2b)">Diff</a>