### PR TITLE
Remove redundant line

### DIFF
--- a/index.html
+++ b/index.html
@@ -1472,6 +1472,7 @@ Specifications describing these APIs should also:
 
   > It is better to approach [these use cases] with replacement technologies
   that are designed-for-purpose and built to respect user privacy.
+  [[?web-without-3p-cookies]]
 
   For example, they might reveal a performance metric for a website directly
   instead of requiring it to be computed from the timing of
@@ -1480,10 +1481,6 @@ Specifications describing these APIs should also:
   When designing an API like this, aim to ensure that the data it exposes
   doesn't make it cheaper to compute information about people than it would
   have been through other methods.
-
-  > It is better to approach [these use cases] with replacement technologies
-  that are designed-for-purpose and built to respect user privacy.
-  [[?web-without-3p-cookies]]
 </aside>
 
 


### PR DESCRIPTION
A quote was repeated twice in one example.

---

The specific example here seems to be two separate examples, so I'm not sure which of the redundant copies was worth keeping.  I thought it made more sense being left in the middle immediately following the relevant feature being discussed.  Potentially would be better to split the examples, not sure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmocny/privacy-principles/pull/430.html" title="Last updated on Sep 16, 2024, 2:33 PM UTC (ea1b000)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/430/0889270...mmocny:ea1b000.html" title="Last updated on Sep 16, 2024, 2:33 PM UTC (ea1b000)">Diff</a>