### PR TITLE
Remove the endorsement of exchanging personal data for content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2097,11 +2097,6 @@ allowed to do so without the [=actor=] retaliating, for instance by artificially
 unrelated feature, by decreasing the quality of the service, or by trying to cajole, badger, or
 trick the [=person=] into opting back into the [=processing=].
 
-Note that because data is valuable, some sites offer an informed, free, and fair exchange of
-appropriate user information for original content that the site created or paid for the creation of.
-If a user chooses not to participate in such an exchange, denying them access to the site is not
-retaliation.
-
 ## Support Choosing Which Information to Present {#support-choosing-info}
 
 <div class="practice" data-audiences="user-agents">


### PR DESCRIPTION
This reverts #436 and commit 254a8d0dbf553563c5b9f7c01d4cc606a5ce6851. Some folks on the TAG objected to the change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-principles/pull/451.html" title="Last updated on Nov 14, 2024, 6:30 PM UTC (10afc18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/451/48e1a5f...jyasskin:10afc18.html" title="Last updated on Nov 14, 2024, 6:30 PM UTC (10afc18)">Diff</a>