### PR TITLE
Clarify what we mean by “ancillary”

### DIFF
--- a/index.html
+++ b/index.html
@@ -1292,10 +1292,11 @@ the data exposed, is to autogenerate a new email address for each context.
 
 ### Ancillary uses
 
-[=Sites=] sometimes use data in ways that aren't needed for the user's immediate
+[=Sites=] sometimes use data in ways that aren't needed for the user's primary
 goals. For example, they might bill advertisers, measure site performance, or
-tell developers about bugs. These uses are known as <dfn data-lt="ancillary
-use">ancillary uses</dfn>.
+tell developers about bugs. These uses, which provide indirect support for,
+but are not inherent in, the user's primary goals, are known as
+<dfn data-lt="ancillary use">ancillary uses</dfn>.
 
 [=Sites=] can get the data they want for [=ancillary uses=] from a variety of places:
 


### PR DESCRIPTION
The word “ancillary” is fairly obscure even for native English speakers, and many dictionaries do not even provide a definition that conveys the intended meaning as understood by those who chose it. These changes make the intended meaning easier for readers to pick up from context, and addresses the FO on this point raised during AC Review.

Relates to https://github.com/w3ctag/privacy-principles/issues/431


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/privacy-principles/pull/457.html" title="Last updated on Feb 14, 2025, 12:25 AM UTC (36238b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/457/5206db9...fantasai:36238b4.html" title="Last updated on Feb 14, 2025, 12:25 AM UTC (36238b4)">Diff</a>