### PR TITLE
Rework retaliation text

### DIFF
--- a/index.html
+++ b/index.html
@@ -2081,7 +2081,7 @@ or even used to manipulate behaviour and thus reduce [=autonomy=].
 </div>
 
 People should be free to limit the amount of private information they share,
-to request that an actor limit the uses of data already shared,
+to request that an [=actor=] limit the uses of data already shared,
 or that data be deleted.
 When a person chooses to deny or withdraw their permission to use their data,
 retaliation is inappropriate.

--- a/index.html
+++ b/index.html
@@ -1989,7 +1989,7 @@ Simply providing a link to a complex policy is unlikely to mean that the person 
 <p>
   <span class="practicelab" id="principle-minimize-consent-requests">
     An [=actor=] should avoid interrupting a [=person=]'s use of a site for
-	  consent requests when an alternative is available.
+          consent requests when an alternative is available.
   </span>
 </p>
 </div>
@@ -2080,11 +2080,24 @@ or even used to manipulate behaviour and thus reduce [=autonomy=].
   </span>
 </div>
 
-Whenever people have the ability to cause an [=actor=] to process less of their [=data=] or to stop
-carrying out some given set of data processing that is not essential to the service, they must be
-allowed to do so without the [=actor=] retaliating, for instance by artificially removing an
-unrelated feature, by decreasing the quality of the service, or by trying to cajole, badger, or
-trick the [=person=] into opting back into the [=processing=].
+People should be free to limit the amount of private information they share,
+to request that an actor limit the uses of data already shared,
+or that data be deleted.
+When a person chooses to deny or withdraw their permission to use their data,
+retaliation is inappropriate.
+
+It is not retaliation to terminate a service
+when data that is essential to the operation of a service is withheld.
+However, it might be retaliation if withholding data
+results in actions unrelated to the use of that data.
+Examples of retaliatory behavior include:
+
+* making the process of withdrawing consent more onerous than granting it;
+
+* using threats, badgering, or trickery ([[?dark-patterns]])
+  to encourage people to reconsider their choice; and,
+
+* denying access to services that do not depend on use of the data.
 
 ## Support Choosing Which Information to Present {#support-choosing-info}
 

--- a/index.html
+++ b/index.html
@@ -2082,14 +2082,14 @@ or even used to manipulate behaviour and thus reduce [=autonomy=].
 
 People should be free to limit the amount of private information they share,
 to request that an [=actor=] limit the uses of data already shared,
-or that data be deleted.
-When a person chooses to deny or withdraw their permission to use their data,
+or that [=data=] be deleted.
+When a [=person=] chooses to deny or withdraw their permission to use their [=data=],
 retaliation is inappropriate.
 
 It is not retaliation to terminate a service
-when data that is essential to the operation of a service is withheld.
-However, it might be retaliation if withholding data
-results in actions unrelated to the use of that data.
+when [=data=] that is essential to the operation of a service is withheld.
+However, it might be retaliation if withholding [=data=]
+results in actions unrelated to the use of that [=data=].
 Examples of retaliatory behavior include:
 
 * making the process of withdrawing consent more onerous than granting it;


### PR DESCRIPTION
This doesn't fundamentally change things, but there are a few subtle differences in how this is presented.

1. It's no longer a single very long sentence.

2. The word "essential" remains attached to the text about service termination.  This remains a pivotal concept here.  I expect that reasonable people will continue to disagree with each other about the degree to which certain data is essential in specific cases.

3. I've included three somewhat general examples of retaliation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/privacy-principles/pull/458.html" title="Last updated on Mar 5, 2025, 9:04 AM UTC (9c1a913)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/privacy-principles/458/5206db9...martinthomson:9c1a913.html" title="Last updated on Mar 5, 2025, 9:04 AM UTC (9c1a913)">Diff</a>